### PR TITLE
fix: declare dotenv as a direct devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/node": "^25",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.6",
     "tailwindcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)


### PR DESCRIPTION
## Summary
Fixes the build break in `prisma.config.ts:3` (`import "dotenv/config"`). `dotenv` was present only **transitively**, so under pnpm's isolated `node_modules` it wasn't resolvable from the project root and the build failed type-checking with `Cannot find module or type declarations for side-effect import of 'dotenv/config'`.

**Change (one concern):**
- Declare `dotenv@^17.4.2` (the already-resolved version) as a direct **devDependency** — matching Prisma's own scaffold note (`npm install --save-dev prisma dotenv`).
- `pnpm-lock.yaml` updated to **promote** dotenv to a direct dep: same version `17.4.2`, no other dependency touched (+3 lines in the `importers` block only).

## Validation (red → green)
- Before: `pnpm build` fails at typecheck on `prisma.config.ts:3`.
- After: `pnpm build` exits `0` (compile + typecheck + sitemap generation all pass).
- `pnpm install --frozen-lockfile` consistent.

## Scope
- Files changed: `package.json` (+1), `pnpm-lock.yaml` (+3). **No application code.**

## Coordination note
Open **PR #45** also edits `package.json` (the `packageManager` field, near the top). This PR edits the `devDependencies` block — different region, no real conflict, but recommend merging #45 first, then this one may need a trivial rebase.

Do not self-merge — for review.