### PR TITLE
fix: per-page canonical URLs (resolves H1, issue #48)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   title: "About Us | SouthStar Charters",
   description:
     "Meet the captain and crew behind SouthStar Charters. Learn about our boats, our mission, and why we are Staten Island's premier charter service.",
+  alternates: { canonical: "/about" },
 };
 
 export default function AboutPage() {

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   title: "Contact Us | SouthStar Charters",
   description:
     "Get in touch with SouthStar Charters to book your private harbor tour, fishing charter, or dive trip. Call (833) 464-8687 or send us a message.",
+  alternates: { canonical: "/contact" },
 };
 
 export default function ContactPage() {

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   title: "Frequently Asked Questions | SouthStar Charters",
   description:
     "Find answers to common questions about SouthStar Charters, including what to bring, weather policies, fishing licenses, and booking information.",
+  alternates: { canonical: "/faq" },
 };
 
 export default function FAQPage() {

--- a/app/fishing-charters/page.tsx
+++ b/app/fishing-charters/page.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
   title: "Fishing Charters — Inshore & Offshore | SouthStar Charters",
   description:
     "Inshore, midshore, and offshore fishing charters along the New Jersey coast. Striped Bass, Tuna, Bluefish, and more. Year-round trips from Belmar and Barnegat Light, NJ.",
+  alternates: { canonical: "/fishing-charters" },
 };
 
 const { fishingCharters } = services;

--- a/app/gallery/layout.tsx
+++ b/app/gallery/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+// The gallery page is a client component and cannot export `metadata`,
+// so its canonical URL is declared here in a route-level layout.
+export const metadata: Metadata = {
+  alternates: { canonical: "/gallery" },
+};
+
+export default function GalleryLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/harbor-tours/page.tsx
+++ b/app/harbor-tours/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: "NYC Harbor Sightseeing Tours | SouthStar Charters",
   description:
     "Experience the Statue of Liberty and the New York skyline on a private luxury yacht. VIP-style harbor tours for up to 13 guests from Staten Island, NY.",
+  alternates: { canonical: "/harbor-tours" },
 };
 
 const { harborTours } = services;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,9 +47,6 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
-  alternates: {
-    canonical: siteConfig.url,
-  },
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import Image from "next/image";
 import Hero from "@/components/Hero";
@@ -5,6 +6,10 @@ import TestimonialPreview from "@/components/TestimonialPreview";
 import GalleryPreview from "@/components/GalleryPreview";
 import CTASection from "@/components/CTASection";
 import faqItems from "@/content/faq.json";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/" },
+};
 
 export default function HomePage() {
   return (

--- a/app/rates/page.tsx
+++ b/app/rates/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: "Charter Rates & Pricing | SouthStar Charters",
   description:
     "View our full list of charter rates for offshore, midshore, and inshore fishing, beach trips, and spearfishing. Transparent pricing from SouthStar Charters.",
+  alternates: { canonical: "/rates" },
 };
 
 export default function RatesPage() {

--- a/app/reviews/page.tsx
+++ b/app/reviews/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   title: "Customer Reviews | SouthStar Charters",
   description:
     "Read what our guests have to say about their experience with SouthStar Charters. Real reviews from real customers.",
+  alternates: { canonical: "/reviews" },
 };
 
 function StarRating({ rating }: { rating: number }) {


### PR DESCRIPTION
Closes #48.

## Problem
`app/layout.tsx` set `alternates.canonical` to the homepage in the root layout. Next.js inherits `alternates` into every route, so **all subpages declared the homepage as their canonical URL** — search engines could treat them as duplicates of `/` and drop them from the index.

## Fix (one concern — canonical URLs)
- Remove the global canonical from `app/layout.tsx` (keep `metadataBase` so relative canonicals resolve). This also prevents the bug silently recurring for future pages.
- Add a self-referential `alternates.canonical` to every route's metadata: `/` (home), `/about`, `/contact`, `/faq`, `/fishing-charters`, `/harbor-tours`, `/rates`, `/reviews`.
- Add `app/gallery/layout.tsx` so the **client-component** gallery page (which can't export `metadata`) declares its own canonical `/gallery`.

## Validation (red → green, from built HTML)
`pnpm build` exits `0`; canonical tag per built page:

| Page | canonical |
|---|---|
| `/` | `https://southstarchartersnj.com` |
| `/about` | `.../about` |
| `/contact` | `.../contact` |
| `/faq` | `.../faq` |
| `/fishing-charters` | `.../fishing-charters` |
| `/gallery` | `.../gallery` |
| `/harbor-tours` | `.../harbor-tours` |
| `/rates` | `.../rates` |
| `/reviews` | `.../reviews` |

Every page is now self-referential; no page points at the wrong URL.

## Scope
- 10 files, all under `app/`, metadata only — no logic, no deps, no lockfile changes.
- **Out of scope (held):** the root layout's `openGraph.url` is also homepage-wide (secondary item noted in #48). Left untouched to keep this one concern.

Do not self-merge — for review.