### PR TITLE
feat: North Atlantic species & seasons page with dynamic, per-jurisdiction calendar

### DIFF
--- a/app/species/page.tsx
+++ b/app/species/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next";
+import SeasonCalendar from "@/components/SeasonCalendar";
+import CaptainTrustPanel from "@/components/CaptainTrustPanel";
+import CTASection from "@/components/CTASection";
+import { species } from "@/lib/data/speciesSeasons";
+
+export const metadata: Metadata = {
+  title: "North Atlantic Fish Species & Seasons | SouthStar Charters",
+  description:
+    "Target species in North Atlantic federal, interstate, and state waters, with a month-by-month season calendar. Seasons differ by jurisdiction — always confirm current regulations before fishing.",
+  alternates: { canonical: "/species" },
+  openGraph: {
+    type: "website",
+    url: "/species",
+    title: "North Atlantic Fish Species & Seasons | SouthStar Charters",
+    description:
+      "Target species in North Atlantic waters with a dynamic, month-by-month season calendar across federal, interstate, and state jurisdictions.",
+  },
+};
+
+// Re-render hourly so the "in season now" status stays current as dates pass,
+// while remaining server-rendered (and therefore crawlable).
+export const revalidate = 3600;
+
+export default function SpeciesPage() {
+  const today = new Date();
+
+  return (
+    <>
+      {/* ── Header ───────────────────────────────────────────────────── */}
+      <section className="bg-slate-900 px-4 py-16 text-center text-white sm:py-20">
+        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+          North Atlantic Fish Species &amp; Seasons
+        </h1>
+        <p className="mx-auto mt-3 max-w-2xl text-lg text-slate-300">
+          The fish we target off the New York and New Jersey coast — and a
+          month-by-month look at when each is in season across federal,
+          interstate, and state waters.
+        </p>
+      </section>
+
+      {/* ── Data disclaimer (required) ───────────────────────────────── */}
+      <section className="px-4 pt-10">
+        <div className="mx-auto max-w-5xl rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+          <p className="font-semibold">Important — verify before you fish.</p>
+          <p className="mt-1 leading-relaxed">
+            Fishing seasons, size limits, and bag limits vary by species and by
+            federal, interstate, and state jurisdiction, change frequently, and
+            are subject to NOAA Fisheries, ASMFC, and NJ Division of Fish &amp;
+            Wildlife regulation. Always confirm current regulations with the
+            governing authority before fishing.
+          </p>
+          <p className="mt-2 text-xs text-amber-800">
+            The dates and limits below are unverified placeholders pending owner
+            confirmation — they are not current regulatory data.
+          </p>
+        </div>
+      </section>
+
+      {/* ── How to read this ─────────────────────────────────────────── */}
+      <section className="px-4 pt-8">
+        <div className="mx-auto max-w-5xl text-sm text-slate-600">
+          <p>
+            The same fish can be open in one jurisdiction and closed in another,
+            so each species lists its season separately by authority:{" "}
+            <span className="font-medium text-slate-800">Federal</span> (NOAA
+            Fisheries, 3–200 nmi),{" "}
+            <span className="font-medium text-slate-800">Interstate</span>{" "}
+            (ASMFC migratory species), and{" "}
+            <span className="font-medium text-slate-800">State</span> (NJ Fish
+            &amp; Wildlife, 0–3 nmi). Highly Migratory Species such as tuna and
+            sharks also require a NOAA HMS permit.
+          </p>
+        </div>
+      </section>
+
+      {/* ── Species & season calendar ────────────────────────────────── */}
+      <section className="px-4 py-12 sm:py-16">
+        <div className="mx-auto max-w-5xl">
+          <SeasonCalendar speciesList={species} referenceDate={today} />
+        </div>
+      </section>
+
+      {/* ── Captain / vessel trust (separate from seasons) ───────────── */}
+      <CaptainTrustPanel />
+
+      {/* ── CTA ──────────────────────────────────────────────────────── */}
+      <CTASection
+        title="Ready to Get on the Fish?"
+        description="Book a North Atlantic fishing charter with SouthStar Charters and let our licensed captain put you on the bite."
+        buttonLabel="Book a Charter"
+      />
+    </>
+  );
+}

--- a/components/CaptainTrustPanel.tsx
+++ b/components/CaptainTrustPanel.tsx
@@ -1,0 +1,75 @@
+/**
+ * Captain & vessel credentialing — TRUST content, NOT seasons data.
+ *
+ * The U.S. Coast Guard governs whether a charter trip is legal to operate
+ * (captain licensing, vessel safety/inspection, passenger limits) — it does NOT
+ * set fishing seasons. This panel is therefore kept architecturally separate
+ * from the seasons engine (lib/seasons.ts / SeasonCalendar).
+ *
+ * All copy below is PLACEHOLDER and must be confirmed by the owner against the
+ * vessel's actual credentials before publish.
+ */
+
+interface TrustItem {
+  title: string;
+  body: string;
+  verify: true;
+}
+
+const TRUST_ITEMS: TrustItem[] = [
+  {
+    title: "USCG-Licensed Captain",
+    body: "PLACEHOLDER — confirm the captain's actual U.S. Coast Guard credential (e.g. OUPV “six-pack” or Master license) and license number before publishing.",
+    verify: true,
+  },
+  {
+    title: "Inspected, Equipped Vessel",
+    body: "PLACEHOLDER — confirm safety equipment, documented vessel status, and any inspection details for the actual boat before publishing.",
+    verify: true,
+  },
+  {
+    title: "Passenger Limits",
+    body: "PLACEHOLDER — confirm the legal maximum number of passengers for the vessel and license class before publishing.",
+    verify: true,
+  },
+];
+
+export default function CaptainTrustPanel() {
+  return (
+    <section className="bg-slate-50 px-4 py-16 sm:py-20">
+      <div className="mx-auto max-w-5xl">
+        <h2 className="text-center text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+          Licensed, Legal &amp; Safe to Operate
+        </h2>
+        <p className="mx-auto mt-3 max-w-2xl text-center text-lg text-slate-600">
+          Fishing seasons are set by NOAA, ASMFC, and the states — but whether a
+          charter is legal to run is governed by the U.S. Coast Guard. Here is how
+          we keep your trip compliant and safe.
+        </p>
+
+        <div className="mt-10 grid gap-6 sm:grid-cols-3">
+          {TRUST_ITEMS.map((item) => (
+            <div
+              key={item.title}
+              className="rounded-xl bg-white p-6 shadow-sm ring-1 ring-slate-200"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <h3 className="text-lg font-semibold text-slate-900">
+                  {item.title}
+                </h3>
+                {item.verify && (
+                  <span className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
+                    Unverified
+                  </span>
+                )}
+              </div>
+              <p className="mt-2 text-sm leading-relaxed text-slate-600">
+                {item.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/SeasonCalendar.tsx
+++ b/components/SeasonCalendar.tsx
@@ -72,6 +72,7 @@ export default function SeasonCalendar({
               const status = getSeasonStatus(season, referenceDate);
               const months = monthsInWindow(season);
               const jur = JURISDICTION_LABELS[season.jurisdiction];
+              const isPending = status === "pending";
               const inSeason = status === "in";
               return (
                 <div
@@ -90,71 +91,88 @@ export default function SeasonCalendar({
                     <span
                       className={cn(
                         "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1",
-                        inSeason
-                          ? "bg-green-100 text-green-800 ring-green-200"
-                          : "bg-slate-100 text-slate-600 ring-slate-200"
+                        isPending
+                          ? "bg-amber-100 text-amber-800 ring-amber-200"
+                          : inSeason
+                            ? "bg-green-100 text-green-800 ring-green-200"
+                            : "bg-slate-100 text-slate-600 ring-slate-200"
                       )}
                     >
-                      {inSeason ? "In season now" : "Out of season"}
+                      {isPending
+                        ? "Dates pending verification"
+                        : inSeason
+                          ? "In season now"
+                          : "Out of season"}
                     </span>
                   </div>
 
-                  {/* Text summary (crawlable) */}
-                  <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-sm sm:grid-cols-4">
-                    <div>
-                      <dt className="text-xs font-medium text-slate-500">
-                        Open window
-                      </dt>
-                      <dd className="text-slate-800">
-                        {fmtRange(season.openDate, season.closeDate)}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs font-medium text-slate-500">
-                        Min. size
-                      </dt>
-                      <dd className="text-slate-800">
-                        {season.minSizeInches != null
-                          ? `${season.minSizeInches} in`
-                          : "—"}
-                      </dd>
-                    </div>
-                    <div>
-                      <dt className="text-xs font-medium text-slate-500">
-                        Bag limit
-                      </dt>
-                      <dd className="text-slate-800">
-                        {season.bagLimit != null ? `${season.bagLimit}` : "—"}
-                      </dd>
-                    </div>
-                    <div className="col-span-2 sm:col-span-1">
-                      <dt className="text-xs font-medium text-slate-500">
-                        Notes
-                      </dt>
-                      <dd className="text-slate-600">{season.notes ?? "—"}</dd>
-                    </div>
-                  </dl>
+                  {isPending ? (
+                    /* No verified data yet — make no in/out claim. */
+                    <p className="mt-2 text-sm text-slate-600">
+                      Season dates and limits are pending owner verification
+                      against {jur.authority}.
+                      {season.notes ? ` (${season.notes})` : ""}
+                    </p>
+                  ) : (
+                    <>
+                      {/* Text summary (crawlable) */}
+                      <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-sm sm:grid-cols-4">
+                        <div>
+                          <dt className="text-xs font-medium text-slate-500">
+                            Open window
+                          </dt>
+                          <dd className="text-slate-800">
+                            {fmtRange(season.openDate, season.closeDate)}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs font-medium text-slate-500">
+                            Min. size
+                          </dt>
+                          <dd className="text-slate-800">
+                            {season.minSizeInches != null
+                              ? `${season.minSizeInches} in`
+                              : "—"}
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className="text-xs font-medium text-slate-500">
+                            Bag limit
+                          </dt>
+                          <dd className="text-slate-800">
+                            {season.bagLimit != null ? `${season.bagLimit}` : "—"}
+                          </dd>
+                        </div>
+                        <div className="col-span-2 sm:col-span-1">
+                          <dt className="text-xs font-medium text-slate-500">
+                            Notes
+                          </dt>
+                          <dd className="text-slate-600">{season.notes ?? "—"}</dd>
+                        </div>
+                      </dl>
 
-                  {/* Month-by-month visual strip */}
-                  <div
-                    className="mt-3 grid grid-cols-12 gap-0.5"
-                    aria-label={`${sp.commonName} ${jur.label} open months`}
-                  >
-                    {months.map((openThisMonth, m) => (
+                      {/* Month-by-month visual strip */}
                       <div
-                        key={m}
-                        className={cn(
-                          "flex h-7 items-center justify-center rounded text-[10px] font-medium",
-                          openThisMonth
-                            ? "bg-green-500/80 text-white"
-                            : "bg-slate-100 text-slate-400"
-                        )}
-                        title={openThisMonth ? "Open (placeholder)" : "Closed (placeholder)"}
+                        className="mt-3 grid grid-cols-12 gap-0.5"
+                        aria-label={`${sp.commonName} ${jur.label} open months`}
                       >
-                        {MONTH_ABBREVIATIONS[m]}
+                        {months.map((openThisMonth, m) => (
+                          <div
+                            key={m}
+                            className={cn(
+                              "flex h-7 items-center justify-center rounded text-[10px] font-medium",
+                              openThisMonth
+                                ? "bg-green-500/80 text-white"
+                                : "bg-slate-100 text-slate-400"
+                            )}
+                            title={openThisMonth ? "Open" : "Closed"}
+                          >
+                            {MONTH_ABBREVIATIONS[m]}
+                          </div>
+                        ))}
                       </div>
-                    ))}
-                  </div>
+                    </>
+                  )}
                 </div>
               );
             })}

--- a/components/SeasonCalendar.tsx
+++ b/components/SeasonCalendar.tsx
@@ -1,0 +1,166 @@
+import { cn } from "@/lib/utils";
+import {
+  JURISDICTION_LABELS,
+  type Species,
+} from "@/lib/data/speciesSeasons";
+import {
+  getSeasonStatus,
+  monthsInWindow,
+  MONTH_ABBREVIATIONS,
+} from "@/lib/seasons";
+
+interface SeasonCalendarProps {
+  speciesList: Species[];
+  /** Reference date used to compute in/out-of-season. Defaults to now. */
+  referenceDate?: Date;
+}
+
+/** Small amber badge flagging that the underlying data is an unverified placeholder. */
+function UnverifiedBadge() {
+  return (
+    <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
+      Unverified placeholder
+    </span>
+  );
+}
+
+function fmtRange(openDate: string, closeDate: string) {
+  return `${openDate} → ${closeDate}`;
+}
+
+/**
+ * Server-rendered species listing + month-by-month calendar.
+ *
+ * For each species it renders, per governing jurisdiction, whether the season is
+ * currently IN or OUT (computed from `referenceDate`) plus a 12-month open-window
+ * strip. Same-species jurisdiction differences (e.g. state vs federal) are shown
+ * as separate rows so they are never collapsed into one (legally wrong) status.
+ * Everything is plain server-rendered text/markup, so it is fully crawlable.
+ */
+export default function SeasonCalendar({
+  speciesList,
+  referenceDate = new Date(),
+}: SeasonCalendarProps) {
+  return (
+    <div className="space-y-8">
+      {speciesList.map((sp) => (
+        <article
+          key={sp.slug}
+          id={sp.slug}
+          className="rounded-xl bg-white p-6 shadow-sm ring-1 ring-slate-200"
+        >
+          {/* Species header */}
+          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+            <h3 className="text-xl font-bold text-slate-900">{sp.commonName}</h3>
+            <p className="text-sm italic text-slate-500">{sp.scientificName}</p>
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+            <span className="rounded-full bg-slate-100 px-2 py-0.5 font-medium capitalize text-slate-600">
+              {sp.waterType} waters
+            </span>
+            {sp.permitRequired && (
+              <span className="rounded-full bg-sky-100 px-2 py-0.5 font-medium text-sky-800 ring-1 ring-sky-200">
+                NOAA HMS permit required
+              </span>
+            )}
+            {sp.verify && <UnverifiedBadge />}
+          </div>
+
+          {/* Per-jurisdiction seasons */}
+          <div className="mt-5 space-y-5">
+            {sp.seasons.map((season, i) => {
+              const status = getSeasonStatus(season, referenceDate);
+              const months = monthsInWindow(season);
+              const jur = JURISDICTION_LABELS[season.jurisdiction];
+              const inSeason = status === "in";
+              return (
+                <div
+                  key={`${sp.slug}-${season.jurisdiction}-${i}`}
+                  className="border-t border-slate-100 pt-4 first:border-t-0 first:pt-0"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <span className="text-sm font-semibold text-slate-900">
+                        {jur.label}
+                      </span>{" "}
+                      <span className="text-xs text-slate-500">
+                        ({jur.authority})
+                      </span>
+                    </div>
+                    <span
+                      className={cn(
+                        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1",
+                        inSeason
+                          ? "bg-green-100 text-green-800 ring-green-200"
+                          : "bg-slate-100 text-slate-600 ring-slate-200"
+                      )}
+                    >
+                      {inSeason ? "In season now" : "Out of season"}
+                    </span>
+                  </div>
+
+                  {/* Text summary (crawlable) */}
+                  <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-sm sm:grid-cols-4">
+                    <div>
+                      <dt className="text-xs font-medium text-slate-500">
+                        Open window
+                      </dt>
+                      <dd className="text-slate-800">
+                        {fmtRange(season.openDate, season.closeDate)}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-medium text-slate-500">
+                        Min. size
+                      </dt>
+                      <dd className="text-slate-800">
+                        {season.minSizeInches != null
+                          ? `${season.minSizeInches} in`
+                          : "—"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-medium text-slate-500">
+                        Bag limit
+                      </dt>
+                      <dd className="text-slate-800">
+                        {season.bagLimit != null ? `${season.bagLimit}` : "—"}
+                      </dd>
+                    </div>
+                    <div className="col-span-2 sm:col-span-1">
+                      <dt className="text-xs font-medium text-slate-500">
+                        Notes
+                      </dt>
+                      <dd className="text-slate-600">{season.notes ?? "—"}</dd>
+                    </div>
+                  </dl>
+
+                  {/* Month-by-month visual strip */}
+                  <div
+                    className="mt-3 grid grid-cols-12 gap-0.5"
+                    aria-label={`${sp.commonName} ${jur.label} open months`}
+                  >
+                    {months.map((openThisMonth, m) => (
+                      <div
+                        key={m}
+                        className={cn(
+                          "flex h-7 items-center justify-center rounded text-[10px] font-medium",
+                          openThisMonth
+                            ? "bg-green-500/80 text-white"
+                            : "bg-slate-100 text-slate-400"
+                        )}
+                        title={openThisMonth ? "Open (placeholder)" : "Closed (placeholder)"}
+                      >
+                        {MONTH_ABBREVIATIONS[m]}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/docs/species-seasons-data-fill.md
+++ b/docs/species-seasons-data-fill.md
@@ -1,0 +1,69 @@
+# Owner Data-Fill Checklist — Species & Seasons
+
+This page (`/species`) ships with **placeholder data only**. Every season window is
+the sentinel `"00-00"`, every entry is `verify: true`, and the page renders
+"Dates pending verification" with **no** in/out-of-season claim until you fill in
+real values. Nothing on the page is presented as factual until you clear it.
+
+This checklist is the systematic path to clearing every placeholder. All edits are
+in **`lib/data/speciesSeasons.ts`**.
+
+## How to fill one season
+
+For each `season` entry in a species:
+
+1. Replace `openDate: "00-00"` and `closeDate: "00-00"` with the real
+   `"MM-DD"` window from the governing authority. If the season wraps the year
+   end (e.g. autumn → spring), set `closeDate` earlier than `openDate`
+   (e.g. open `"10-10"`, close `"04-30"`) — the calendar handles the wrap.
+2. Add `minSizeInches:` and `bagLimit:` with the confirmed values.
+3. Update `notes:` (or remove the PLACEHOLDER note).
+4. When **all** of a species' seasons are filled and confirmed, change that
+   species' `verify: true` to `verify: false`. The "Unverified placeholder"
+   badge disappears only when `verify` is false.
+
+> Closed for a jurisdiction? Use a window that reflects it, or remove that
+> jurisdiction's season entry. Don't leave `"00-00"` on a published species.
+
+## Sourcing map — which authority each jurisdiction resolves against
+
+| Jurisdiction | Authority to check |
+|---|---|
+| `federal` | **NOAA Fisheries (NMFS)** recreational regs. HMS species also need a **NOAA HMS Angling/Charter permit**. |
+| `interstate` | **ASMFC** fishery management plan, **as implemented by NJ** (NJ adopts the ASMFC-coordinated rule). |
+| `state` | **NJ DEP Division of Fish & Wildlife** marine digest (0–3 nmi). |
+
+## Per-species checklist
+
+Each box is one season window to confirm (open, close, min size, bag limit).
+HMS = requires NOAA Highly Migratory Species permit.
+
+### Inshore / nearshore
+- [ ] **Striped Bass** — `interstate` (ASMFC) · `state` (NJ F&W)
+- [ ] **Summer Flounder (Fluke)** — `federal` (NOAA) · `state` (NJ F&W) — *state and federal windows often differ; confirm both*
+- [ ] **Bluefish** — `interstate` (ASMFC)
+- [ ] **Weakfish** — `interstate` (ASMFC) · `state` (NJ F&W)
+- [ ] **False Albacore (Little Tunny)** — `state` (NJ F&W) — *confirm whether NJ sets any limit*
+- [ ] **Atlantic Bonito** — `state` (NJ F&W) — *confirm whether NJ sets any limit*
+
+### Offshore canyons
+- [ ] **Bluefin Tuna** — `federal` (NOAA **HMS**) — *category/size-class rules change in-season*
+- [ ] **Yellowfin Tuna** — `federal` (NOAA **HMS**)
+- [ ] **Big-Eye Tuna** — `federal` (NOAA **HMS**)
+- [ ] **Longfin Tuna (Albacore)** — `federal` (NOAA **HMS**)
+- [ ] **Mahi (Dolphinfish)** — `federal` (Mid-Atlantic FMP) — *no HMS permit*
+- [ ] **Wahoo** — `federal` — *no HMS permit*
+- [ ] **Marlin (Billfish)** — `federal` (NOAA **HMS**) — *confirm retention vs catch-and-release / landing rules*
+- [ ] **Swordfish** — `federal` (NOAA **HMS**)
+
+## Before publish
+
+- [ ] Every `"00-00"` replaced with a real window (or the season entry removed).
+- [ ] `minSizeInches` / `bagLimit` filled where the authority sets them.
+- [ ] `permitRequired` still correct (tunas, billfish, swordfish, sharks = `true`).
+- [ ] All confirmed species set to `verify: false`.
+- [ ] Re-read the on-page disclaimer — it stays regardless; regulations change.
+
+> Reminder: seasons and limits change yearly (and sometimes in-season). Even after
+> filling, the disclaimer and a periodic re-check against NOAA / ASMFC / NJ F&W
+> remain necessary.

--- a/lib/data/speciesSeasons.ts
+++ b/lib/data/speciesSeasons.ts
@@ -2,55 +2,69 @@
  * North Atlantic Fish Species & Seasons — OWNER-CONTROLLED DATA
  * ============================================================================
  *
- * ⚠️  EVERY season date, size limit, and bag limit in this file is a PLACEHOLDER.
- *     Nothing here is real regulatory data. The page renders an "Unverified"
- *     badge on every entry (driven by `verify: true`) so nothing false can ship.
+ * ⚠️  EVERY season window, size limit, and bag limit in this file is an
+ *     UNFILLED PLACEHOLDER. There is NO real regulatory data here.
  *
- *     The site owner MUST replace these with current, confirmed values and clear
- *     the `verify` flag, after checking the governing authority for EACH season:
- *       - federal     → NOAA Fisheries (NMFS), 3–200 nmi
- *       - interstate  → ASMFC (Atlantic States Marine Fisheries Commission)
- *       - state       → NJ Division of Fish & Wildlife (NJDEP), 0–3 nmi
+ *     Placeholder windows use the SENTINEL value "00-00" (an impossible date) so
+ *     they are self-evidently fake at the data layer — not just behind a UI
+ *     badge. The calendar special-cases the sentinel and renders "Season dates
+ *     pending verification" instead of any in/out-of-season claim. This fails
+ *     CLOSED at the source: nothing here can be mistaken for a verified value.
+ *
+ *     To publish, the owner replaces each "00-00" window with a real "MM-DD"
+ *     range, fills minSizeInches / bagLimit, and clears `verify`, after checking
+ *     the governing authority for EACH season (see sourcing map below).
+ *
+ * Sourcing map (which authority each jurisdiction resolves against)
+ * ----------------------------------------------------------------------------
+ *   "federal"     → NOAA Fisheries (NMFS). HMS species (tunas, billfish,
+ *                   swordfish, sharks) also require a NOAA HMS Angling/Charter
+ *                   permit and are federally managed — flagged `permitRequired`.
+ *   "interstate"  → ASMFC fishery management plans, as implemented by NJ
+ *                   (striped bass, summer flounder, bluefish, weakfish, …).
+ *   "state"       → NJ DEP Division of Fish & Wildlife marine digest (0–3 nmi).
  *
  * Schema
  * ----------------------------------------------------------------------------
- *   Jurisdiction  "federal" | "interstate" | "state"
- *                 The authority that governs a given season window. The SAME
- *                 species can be open in one jurisdiction and closed in another
- *                 (e.g. summer flounder in state vs federal waters) — this is why
+ *   Jurisdiction  "federal" | "interstate" | "state" — the authority for a given
+ *                 window. The SAME species can be open in one jurisdiction and
+ *                 closed in another (e.g. summer flounder state vs federal), so
  *                 `seasons` is an array keyed by jurisdiction, never a flat field.
  *
  *   Season
  *     jurisdiction    Jurisdiction (above)
- *     openDate        "MM-DD" — first day of the open window
- *     closeDate       "MM-DD" — last day of the open window. If closeDate is
- *                     earlier than openDate, the window WRAPS the year end
- *                     (e.g. open 10-10, close 04-30 = mid-Oct through end of Apr).
- *     minSizeInches?  optional minimum legal size
- *     bagLimit?       optional per-angler daily bag limit
- *     notes?          free text (kept short; shown under the season)
+ *     openDate        "MM-DD", or the sentinel "00-00" while unverified
+ *     closeDate       "MM-DD", or the sentinel "00-00" while unverified.
+ *                     For real data, if closeDate < openDate the window WRAPS the
+ *                     year end (e.g. open 10-10, close 04-30).
+ *     minSizeInches?  optional minimum legal size (omit while unverified)
+ *     bagLimit?       optional per-angler daily bag limit (omit while unverified)
+ *     notes?          short free text shown under the season
  *
  *   Species
  *     commonName      e.g. "Striped Bass"
  *     scientificName  e.g. "Morone saxatilis"
- *     slug            URL-safe id, also used as React key
+ *     slug            URL-safe id, also the React key
  *     waterType       "inshore" | "offshore" | "both"
- *     permitRequired  true for Highly Migratory Species (HMS) that need a NOAA
- *                     HMS permit — tuna, sharks, billfish, swordfish
+ *     permitRequired  true for NOAA HMS species (tunas, billfish, swordfish,
+ *                     sharks) that need a federal HMS permit
  *     seasons         Season[] — one entry per governing jurisdiction
- *     verify          ALWAYS true here. Drives the "Unverified placeholder"
- *                     badge in the UI. Owner sets to false only after confirming.
+ *     verify          ALWAYS true here; drives the "Unverified placeholder"
+ *                     badge. Owner sets false only after confirming real data.
  *
- * Dates are intentionally rounded/synthetic placeholders, not real-looking
- * regulatory dates, to make it obvious they are demo values pending verification.
+ * Species list is grounded in content/rates.json (the charter's stated target
+ * species), not model knowledge.
  */
 
 export type Jurisdiction = "federal" | "interstate" | "state";
 
+/** Sentinel window value meaning "not yet filled / pending verification". */
+export const PLACEHOLDER_DATE = "00-00";
+
 export interface Season {
   jurisdiction: Jurisdiction;
-  openDate: string; // "MM-DD"
-  closeDate: string; // "MM-DD"
+  openDate: string; // "MM-DD" or PLACEHOLDER_DATE
+  closeDate: string; // "MM-DD" or PLACEHOLDER_DATE
   minSizeInches?: number;
   bagLimit?: number;
   notes?: string;
@@ -76,11 +90,24 @@ export const JURISDICTION_LABELS: Record<
   state: { label: "State", authority: "NJ Fish & Wildlife (0–3 nmi)" },
 };
 
+/** Every season starts as an unfilled, sentinel placeholder. // VERIFY before publish. */
+function pending(jurisdiction: Jurisdiction, notes: string): Season {
+  // VERIFY: owner replaces 00-00 with a real MM-DD window + size/bag from the
+  // governing authority (see sourcing map in the file header) before publish.
+  return {
+    jurisdiction,
+    openDate: PLACEHOLDER_DATE,
+    closeDate: PLACEHOLDER_DATE,
+    notes,
+  };
+}
+
 /**
- * PLACEHOLDER DATA — replace before publish. See header.
- * Each season carries a // VERIFY marker as a standing reminder.
+ * Target species, grounded in content/rates.json. ALL seasons are unfilled
+ * sentinel placeholders pending owner verification.
  */
 export const species: Species[] = [
+  // ── Inshore / nearshore (state + interstate jurisdictions matter here) ──
   {
     commonName: "Striped Bass",
     scientificName: "Morone saxatilis",
@@ -88,10 +115,8 @@ export const species: Species[] = [
     waterType: "inshore",
     permitRequired: false,
     seasons: [
-      // VERIFY: owner confirms vs ASMFC before publish
-      { jurisdiction: "interstate", openDate: "05-01", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — not real regulatory data" },
-      // VERIFY: owner confirms vs NJ Fish & Wildlife before publish
-      { jurisdiction: "state", openDate: "03-01", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — not real regulatory data" },
+      pending("interstate", "PLACEHOLDER — ASMFC striped bass plan, pending verification"),
+      pending("state", "PLACEHOLDER — NJ state waters, pending verification"),
     ],
     verify: true,
   },
@@ -102,34 +127,8 @@ export const species: Species[] = [
     waterType: "both",
     permitRequired: false,
     seasons: [
-      // VERIFY: owner confirms vs NOAA Fisheries before publish — state and federal windows DIFFER for this species
-      { jurisdiction: "federal", openDate: "06-01", closeDate: "09-30", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — federal window differs from state" },
-      // VERIFY: owner confirms vs NJ Fish & Wildlife before publish
-      { jurisdiction: "state", openDate: "05-01", closeDate: "09-30", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — state window differs from federal" },
-    ],
-    verify: true,
-  },
-  {
-    commonName: "Black Sea Bass",
-    scientificName: "Centropristis striata",
-    slug: "black-sea-bass",
-    waterType: "both",
-    permitRequired: false,
-    seasons: [
-      // VERIFY: owner confirms vs ASMFC before publish
-      { jurisdiction: "interstate", openDate: "05-15", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — not real regulatory data" },
-    ],
-    verify: true,
-  },
-  {
-    commonName: "Scup (Porgy)",
-    scientificName: "Stenotomus chrysops",
-    slug: "scup-porgy",
-    waterType: "inshore",
-    permitRequired: false,
-    seasons: [
-      // VERIFY: owner confirms vs ASMFC before publish
-      { jurisdiction: "interstate", openDate: "01-01", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — not real regulatory data" },
+      pending("federal", "PLACEHOLDER — federal window may differ from state, pending verification"),
+      pending("state", "PLACEHOLDER — NJ state window, pending verification"),
     ],
     verify: true,
   },
@@ -139,58 +138,111 @@ export const species: Species[] = [
     slug: "bluefish",
     waterType: "both",
     permitRequired: false,
-    seasons: [
-      // VERIFY: owner confirms vs ASMFC before publish
-      { jurisdiction: "interstate", openDate: "01-01", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — not real regulatory data" },
-    ],
+    seasons: [pending("interstate", "PLACEHOLDER — ASMFC bluefish plan, pending verification")],
     verify: true,
   },
   {
-    commonName: "Tautog (Blackfish)",
-    scientificName: "Tautoga onitis",
-    slug: "tautog-blackfish",
+    commonName: "Weakfish",
+    scientificName: "Cynoscion regalis",
+    slug: "weakfish",
     waterType: "inshore",
     permitRequired: false,
     seasons: [
-      // VERIFY: owner confirms vs NJ Fish & Wildlife before publish — this window WRAPS the year end
-      { jurisdiction: "state", openDate: "10-10", closeDate: "04-30", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — wraps year end (autumn through spring)" },
+      pending("interstate", "PLACEHOLDER — ASMFC weakfish plan, pending verification"),
+      pending("state", "PLACEHOLDER — NJ state waters, pending verification"),
     ],
     verify: true,
   },
   {
-    commonName: "Atlantic Cod",
-    scientificName: "Gadus morhua",
-    slug: "atlantic-cod",
-    waterType: "offshore",
+    commonName: "False Albacore (Little Tunny)",
+    scientificName: "Euthynnus alletteratus",
+    slug: "false-albacore",
+    waterType: "inshore",
     permitRequired: false,
-    seasons: [
-      // VERIFY: owner confirms vs NOAA Fisheries before publish
-      { jurisdiction: "federal", openDate: "09-01", closeDate: "04-30", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — wraps year end" },
-    ],
+    seasons: [pending("state", "PLACEHOLDER — confirm NJ status, pending verification")],
     verify: true,
   },
+  {
+    commonName: "Atlantic Bonito",
+    scientificName: "Sarda sarda",
+    slug: "atlantic-bonito",
+    waterType: "inshore",
+    permitRequired: false,
+    seasons: [pending("state", "PLACEHOLDER — confirm NJ status, pending verification")],
+    verify: true,
+  },
+
+  // ── Offshore canyons — HMS species are federally managed & permit-required ──
   {
     commonName: "Bluefin Tuna",
     scientificName: "Thunnus thynnus",
     slug: "bluefin-tuna",
     waterType: "offshore",
-    permitRequired: true, // NOAA HMS permit required
-    seasons: [
-      // VERIFY: owner confirms vs NOAA Fisheries (HMS) before publish
-      { jurisdiction: "federal", openDate: "06-01", closeDate: "11-30", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — requires NOAA HMS permit" },
-    ],
+    permitRequired: true, // NOAA HMS
+    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS, pending verification")],
     verify: true,
   },
   {
-    commonName: "Shortfin Mako Shark",
-    scientificName: "Isurus oxyrinchus",
-    slug: "shortfin-mako-shark",
+    commonName: "Yellowfin Tuna",
+    scientificName: "Thunnus albacares",
+    slug: "yellowfin-tuna",
     waterType: "offshore",
-    permitRequired: true, // NOAA HMS permit required
-    seasons: [
-      // VERIFY: owner confirms vs NOAA Fisheries (HMS) before publish — retention rules change frequently
-      { jurisdiction: "federal", openDate: "01-01", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — requires NOAA HMS permit; confirm retention status" },
-    ],
+    permitRequired: true, // NOAA HMS
+    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS, pending verification")],
+    verify: true,
+  },
+  {
+    commonName: "Big-Eye Tuna",
+    scientificName: "Thunnus obesus",
+    slug: "big-eye-tuna",
+    waterType: "offshore",
+    permitRequired: true, // NOAA HMS
+    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS, pending verification")],
+    verify: true,
+  },
+  {
+    commonName: "Longfin Tuna (Albacore)",
+    scientificName: "Thunnus alalunga",
+    slug: "longfin-tuna-albacore",
+    waterType: "offshore",
+    permitRequired: true, // NOAA HMS
+    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS, pending verification")],
+    verify: true,
+  },
+  {
+    commonName: "Mahi (Dolphinfish)",
+    scientificName: "Coryphaena hippurus",
+    slug: "mahi-dolphinfish",
+    waterType: "offshore",
+    permitRequired: false, // federally managed (Mid-Atlantic) but NOT an HMS permit species
+    seasons: [pending("federal", "PLACEHOLDER — Mid-Atlantic FMP, pending verification")],
+    verify: true,
+  },
+  {
+    commonName: "Wahoo",
+    scientificName: "Acanthocybium solandri",
+    slug: "wahoo",
+    waterType: "offshore",
+    permitRequired: false, // federally managed but NOT an HMS permit species
+    seasons: [pending("federal", "PLACEHOLDER — federal management, pending verification")],
+    verify: true,
+  },
+  {
+    commonName: "Marlin (Billfish)",
+    scientificName: "Istiophoridae spp.",
+    slug: "marlin-billfish",
+    waterType: "offshore",
+    permitRequired: true, // NOAA HMS billfish
+    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS billfish, pending verification")],
+    verify: true,
+  },
+  {
+    commonName: "Swordfish",
+    scientificName: "Xiphias gladius",
+    slug: "swordfish",
+    waterType: "offshore",
+    permitRequired: true, // NOAA HMS
+    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS, pending verification")],
     verify: true,
   },
 ];

--- a/lib/data/speciesSeasons.ts
+++ b/lib/data/speciesSeasons.ts
@@ -1,0 +1,196 @@
+/**
+ * North Atlantic Fish Species & Seasons — OWNER-CONTROLLED DATA
+ * ============================================================================
+ *
+ * ⚠️  EVERY season date, size limit, and bag limit in this file is a PLACEHOLDER.
+ *     Nothing here is real regulatory data. The page renders an "Unverified"
+ *     badge on every entry (driven by `verify: true`) so nothing false can ship.
+ *
+ *     The site owner MUST replace these with current, confirmed values and clear
+ *     the `verify` flag, after checking the governing authority for EACH season:
+ *       - federal     → NOAA Fisheries (NMFS), 3–200 nmi
+ *       - interstate  → ASMFC (Atlantic States Marine Fisheries Commission)
+ *       - state       → NJ Division of Fish & Wildlife (NJDEP), 0–3 nmi
+ *
+ * Schema
+ * ----------------------------------------------------------------------------
+ *   Jurisdiction  "federal" | "interstate" | "state"
+ *                 The authority that governs a given season window. The SAME
+ *                 species can be open in one jurisdiction and closed in another
+ *                 (e.g. summer flounder in state vs federal waters) — this is why
+ *                 `seasons` is an array keyed by jurisdiction, never a flat field.
+ *
+ *   Season
+ *     jurisdiction    Jurisdiction (above)
+ *     openDate        "MM-DD" — first day of the open window
+ *     closeDate       "MM-DD" — last day of the open window. If closeDate is
+ *                     earlier than openDate, the window WRAPS the year end
+ *                     (e.g. open 10-10, close 04-30 = mid-Oct through end of Apr).
+ *     minSizeInches?  optional minimum legal size
+ *     bagLimit?       optional per-angler daily bag limit
+ *     notes?          free text (kept short; shown under the season)
+ *
+ *   Species
+ *     commonName      e.g. "Striped Bass"
+ *     scientificName  e.g. "Morone saxatilis"
+ *     slug            URL-safe id, also used as React key
+ *     waterType       "inshore" | "offshore" | "both"
+ *     permitRequired  true for Highly Migratory Species (HMS) that need a NOAA
+ *                     HMS permit — tuna, sharks, billfish, swordfish
+ *     seasons         Season[] — one entry per governing jurisdiction
+ *     verify          ALWAYS true here. Drives the "Unverified placeholder"
+ *                     badge in the UI. Owner sets to false only after confirming.
+ *
+ * Dates are intentionally rounded/synthetic placeholders, not real-looking
+ * regulatory dates, to make it obvious they are demo values pending verification.
+ */
+
+export type Jurisdiction = "federal" | "interstate" | "state";
+
+export interface Season {
+  jurisdiction: Jurisdiction;
+  openDate: string; // "MM-DD"
+  closeDate: string; // "MM-DD"
+  minSizeInches?: number;
+  bagLimit?: number;
+  notes?: string;
+}
+
+export interface Species {
+  commonName: string;
+  scientificName: string;
+  slug: string;
+  waterType: "inshore" | "offshore" | "both";
+  permitRequired: boolean;
+  seasons: Season[];
+  verify: true;
+}
+
+/** Human-readable label + short authority note for each jurisdiction. */
+export const JURISDICTION_LABELS: Record<
+  Jurisdiction,
+  { label: string; authority: string }
+> = {
+  federal: { label: "Federal", authority: "NOAA Fisheries (3–200 nmi)" },
+  interstate: { label: "Interstate", authority: "ASMFC (migratory)" },
+  state: { label: "State", authority: "NJ Fish & Wildlife (0–3 nmi)" },
+};
+
+/**
+ * PLACEHOLDER DATA — replace before publish. See header.
+ * Each season carries a // VERIFY marker as a standing reminder.
+ */
+export const species: Species[] = [
+  {
+    commonName: "Striped Bass",
+    scientificName: "Morone saxatilis",
+    slug: "striped-bass",
+    waterType: "inshore",
+    permitRequired: false,
+    seasons: [
+      // VERIFY: owner confirms vs ASMFC before publish
+      { jurisdiction: "interstate", openDate: "05-01", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — not real regulatory data" },
+      // VERIFY: owner confirms vs NJ Fish & Wildlife before publish
+      { jurisdiction: "state", openDate: "03-01", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — not real regulatory data" },
+    ],
+    verify: true,
+  },
+  {
+    commonName: "Summer Flounder (Fluke)",
+    scientificName: "Paralichthys dentatus",
+    slug: "summer-flounder-fluke",
+    waterType: "both",
+    permitRequired: false,
+    seasons: [
+      // VERIFY: owner confirms vs NOAA Fisheries before publish — state and federal windows DIFFER for this species
+      { jurisdiction: "federal", openDate: "06-01", closeDate: "09-30", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — federal window differs from state" },
+      // VERIFY: owner confirms vs NJ Fish & Wildlife before publish
+      { jurisdiction: "state", openDate: "05-01", closeDate: "09-30", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — state window differs from federal" },
+    ],
+    verify: true,
+  },
+  {
+    commonName: "Black Sea Bass",
+    scientificName: "Centropristis striata",
+    slug: "black-sea-bass",
+    waterType: "both",
+    permitRequired: false,
+    seasons: [
+      // VERIFY: owner confirms vs ASMFC before publish
+      { jurisdiction: "interstate", openDate: "05-15", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — not real regulatory data" },
+    ],
+    verify: true,
+  },
+  {
+    commonName: "Scup (Porgy)",
+    scientificName: "Stenotomus chrysops",
+    slug: "scup-porgy",
+    waterType: "inshore",
+    permitRequired: false,
+    seasons: [
+      // VERIFY: owner confirms vs ASMFC before publish
+      { jurisdiction: "interstate", openDate: "01-01", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — not real regulatory data" },
+    ],
+    verify: true,
+  },
+  {
+    commonName: "Bluefish",
+    scientificName: "Pomatomus saltatrix",
+    slug: "bluefish",
+    waterType: "both",
+    permitRequired: false,
+    seasons: [
+      // VERIFY: owner confirms vs ASMFC before publish
+      { jurisdiction: "interstate", openDate: "01-01", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — not real regulatory data" },
+    ],
+    verify: true,
+  },
+  {
+    commonName: "Tautog (Blackfish)",
+    scientificName: "Tautoga onitis",
+    slug: "tautog-blackfish",
+    waterType: "inshore",
+    permitRequired: false,
+    seasons: [
+      // VERIFY: owner confirms vs NJ Fish & Wildlife before publish — this window WRAPS the year end
+      { jurisdiction: "state", openDate: "10-10", closeDate: "04-30", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — wraps year end (autumn through spring)" },
+    ],
+    verify: true,
+  },
+  {
+    commonName: "Atlantic Cod",
+    scientificName: "Gadus morhua",
+    slug: "atlantic-cod",
+    waterType: "offshore",
+    permitRequired: false,
+    seasons: [
+      // VERIFY: owner confirms vs NOAA Fisheries before publish
+      { jurisdiction: "federal", openDate: "09-01", closeDate: "04-30", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — wraps year end" },
+    ],
+    verify: true,
+  },
+  {
+    commonName: "Bluefin Tuna",
+    scientificName: "Thunnus thynnus",
+    slug: "bluefin-tuna",
+    waterType: "offshore",
+    permitRequired: true, // NOAA HMS permit required
+    seasons: [
+      // VERIFY: owner confirms vs NOAA Fisheries (HMS) before publish
+      { jurisdiction: "federal", openDate: "06-01", closeDate: "11-30", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — requires NOAA HMS permit" },
+    ],
+    verify: true,
+  },
+  {
+    commonName: "Shortfin Mako Shark",
+    scientificName: "Isurus oxyrinchus",
+    slug: "shortfin-mako-shark",
+    waterType: "offshore",
+    permitRequired: true, // NOAA HMS permit required
+    seasons: [
+      // VERIFY: owner confirms vs NOAA Fisheries (HMS) before publish — retention rules change frequently
+      { jurisdiction: "federal", openDate: "01-01", closeDate: "12-31", minSizeInches: 0, bagLimit: 0, notes: "PLACEHOLDER — requires NOAA HMS permit; confirm retention status" },
+    ],
+    verify: true,
+  },
+];

--- a/lib/seasons.ts
+++ b/lib/seasons.ts
@@ -8,9 +8,16 @@
  * deterministically — the UI passes `new Date()` for the live view.
  */
 
-import type { Season } from "@/lib/data/speciesSeasons";
+import { PLACEHOLDER_DATE, type Season } from "@/lib/data/speciesSeasons";
 
-export type SeasonStatus = "in" | "out";
+export type SeasonStatus = "in" | "out" | "pending";
+
+/** True when the season window is an unfilled sentinel placeholder ("00-00"). */
+export function isPlaceholderSeason(season: Season): boolean {
+  return (
+    season.openDate === PLACEHOLDER_DATE || season.closeDate === PLACEHOLDER_DATE
+  );
+}
 
 /** Convert "MM-DD" to a comparable ordinal (month * 100 + day). */
 function toOrdinal(mmdd: string): number {
@@ -30,8 +37,13 @@ function ordinalInWindow(ordinal: number, open: number, close: number): boolean 
     : ordinal >= open || ordinal <= close;
 }
 
-/** Is the species' season open on `reference`? */
+/**
+ * Is the species' season open on `reference`?
+ * Returns "pending" for unfilled placeholder windows so the UI never makes an
+ * in/out-of-season claim about unverified data.
+ */
 export function getSeasonStatus(season: Season, reference: Date): SeasonStatus {
+  if (isPlaceholderSeason(season)) return "pending";
   const open = toOrdinal(season.openDate);
   const close = toOrdinal(season.closeDate);
   return ordinalInWindow(dateToOrdinal(reference), open, close) ? "in" : "out";
@@ -42,6 +54,8 @@ export function getSeasonStatus(season: Season, reference: Date): SeasonStatus {
  * A month is marked open if any day within it falls in the window.
  */
 export function monthsInWindow(season: Season): boolean[] {
+  // Placeholder windows have no real coverage — report no open months.
+  if (isPlaceholderSeason(season)) return new Array(12).fill(false);
   const open = toOrdinal(season.openDate);
   const close = toOrdinal(season.closeDate);
   const months: boolean[] = [];

--- a/lib/seasons.ts
+++ b/lib/seasons.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure season-window logic for the species calendar.
+ *
+ * Seasons are stored as "MM-DD" windows that recur every year (see
+ * lib/data/speciesSeasons.ts). A window WRAPS the year end when its closeDate is
+ * earlier than its openDate (e.g. open 10-10, close 04-30). All functions here
+ * are pure and take an explicit reference date so they can be unit-tested
+ * deterministically — the UI passes `new Date()` for the live view.
+ */
+
+import type { Season } from "@/lib/data/speciesSeasons";
+
+export type SeasonStatus = "in" | "out";
+
+/** Convert "MM-DD" to a comparable ordinal (month * 100 + day). */
+function toOrdinal(mmdd: string): number {
+  const [month, day] = mmdd.split("-").map((part) => Number(part));
+  return month * 100 + day;
+}
+
+/** Convert a Date to the same month*100+day ordinal, in local time. */
+function dateToOrdinal(date: Date): number {
+  return (date.getMonth() + 1) * 100 + date.getDate();
+}
+
+/** True if the given ordinal falls inside the (possibly year-wrapping) window. */
+function ordinalInWindow(ordinal: number, open: number, close: number): boolean {
+  return open <= close
+    ? ordinal >= open && ordinal <= close
+    : ordinal >= open || ordinal <= close;
+}
+
+/** Is the species' season open on `reference`? */
+export function getSeasonStatus(season: Season, reference: Date): SeasonStatus {
+  const open = toOrdinal(season.openDate);
+  const close = toOrdinal(season.closeDate);
+  return ordinalInWindow(dateToOrdinal(reference), open, close) ? "in" : "out";
+}
+
+/**
+ * Which of the 12 months the window covers, as a boolean[12] (index 0 = January).
+ * A month is marked open if any day within it falls in the window.
+ */
+export function monthsInWindow(season: Season): boolean[] {
+  const open = toOrdinal(season.openDate);
+  const close = toOrdinal(season.closeDate);
+  const months: boolean[] = [];
+  for (let month = 1; month <= 12; month++) {
+    let anyDayOpen = false;
+    for (let day = 1; day <= 28; day++) {
+      if (ordinalInWindow(month * 100 + day, open, close)) {
+        anyDayOpen = true;
+        break;
+      }
+    }
+    months.push(anyDayOpen);
+  }
+  return months;
+}
+
+export const MONTH_ABBREVIATIONS = [
+  "J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D",
+] as const;

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -29,6 +29,7 @@ export const siteConfig = {
     { label: "Home", href: "/" },
     { label: "Harbor Tours", href: "/harbor-tours" },
     { label: "Fishing Charters", href: "/fishing-charters" },
+    { label: "Species & Seasons", href: "/species" },
     { label: "Rates", href: "/rates" },
     { label: "About", href: "/about" },
     { label: "Gallery", href: "/gallery" },


### PR DESCRIPTION
## Summary
Adds a new **`/species`** page: target North Atlantic species with a month-by-month season calendar that computes **in/out-of-season from today's date**, plus a USCG/captain credentialing trust panel. All regulatory data is **owner-controlled and currently unverified placeholder** — nothing real is invented by the model.

## Regulatory architecture (the important part)
- **Seasons are modeled per jurisdiction** — `federal` (NOAA Fisheries, 3–200 nmi) / `interstate` (ASMFC migratory) / `state` (NJ F&W, 0–3 nmi). The same fish can be open in one and closed in another (the summer-flounder case), so a flat season field would display **legally wrong** info. `seasons` is an array keyed by jurisdiction.
- **Highly Migratory Species** (tuna, shark) carry `permitRequired` → "NOAA HMS permit required" badge.
- **USCG ≠ seasons.** Captain licensing / vessel safety / passenger limits is **trust content**, kept architecturally separate (`CaptainTrustPanel`) from the seasons engine.
- **No invented regulatory data.** Every date/size/limit is a placeholder, marked `// VERIFY` in the data file and badged **"Unverified placeholder"** in the UI, with the required multi-jurisdiction disclaimer rendered on the page. Owner confirms against NOAA / ASMFC / NJ F&W and clears `verify` before publish.

## Files
| File | Purpose |
|---|---|
| `lib/data/speciesSeasons.ts` | Typed, documented schema + placeholder data (jurisdiction dimension, `permitRequired`, `verify`) |
| `lib/seasons.ts` | Pure, testable window logic — handles year-wrapping seasons |
| `components/SeasonCalendar.tsx` | Server-rendered, crawlable per-jurisdiction status + 12-month grid |
| `components/CaptainTrustPanel.tsx` | USCG/captain trust panel (separate concern) |
| `app/species/page.tsx` | Page: disclaimer, per-page canonical `/species`, OpenGraph, `revalidate = 3600` |
| `lib/site.ts` | Nav link to `/species` (approved) |

## Verification
- **Dynamic logic tested** (pure `getSeasonStatus`) across non-wrapping, wrapping, and boundary dates — all pass:
  - summer window: Jul 15 → in, Jan 15 → out
  - wrapping window (Oct 10–Apr 30): Jan 15 → in, Jul 15 → out, Apr 30 → in, May 1 → out
- **`pnpm build` passes**; `/species` builds with 1h revalidate.
- **Built HTML confirmed**: `<link rel="canonical" href=".../species">` (not the homepage — respects the H1 fix), OG url set, disclaimer present, species + scientific names + per-jurisdiction labels render as crawlable text.

## Scope / constraints honored
- One feature; `pnpm-lock.yaml` untouched; no new dependencies; no edits to unrelated routes (only the nav line in `lib/site.ts`). TS strict, no `any`.
- **No runtime/external input** → no Zod added (data is a static, typed build-time import). Validate at the boundary if data later moves to a CMS/API.

## Flagged follow-up (not built — no existing pattern)
- **JSON-LD** (`Dataset`/`ItemList` or `FAQPage`) — the repo has no structured-data pattern today; tracking as a backlog item rather than forcing it in.

Do not self-merge — for review.