### PR TITLE
feat(seo): FAQPage JSON-LD on /faq (AEO Tier-1)

### DIFF
--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import faqItems from "@/content/faq.json";
 import CTASection from "@/components/CTASection";
+import JsonLd from "@/components/JsonLd";
 
 export const metadata: Metadata = {
   title: "Frequently Asked Questions | SouthStar Charters",
@@ -9,9 +10,25 @@ export const metadata: Metadata = {
   alternates: { canonical: "/faq" },
 };
 
+// FAQPage structured data, built from the same content rendered visibly below
+// (Google requires the FAQ content to be present on the page).
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqItems.map((item) => ({
+    "@type": "Question",
+    name: item.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: item.answer,
+    },
+  })),
+};
+
 export default function FAQPage() {
   return (
     <>
+      <JsonLd data={faqJsonLd} />
       {/* ── Header ───────────────────────────────────────────────────── */}
       <section className="bg-slate-900 px-4 py-16 text-center text-white sm:py-20">
         <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,20 @@
+/**
+ * Renders a JSON-LD structured-data block in a <script type="application/ld+json">.
+ *
+ * `data` is a schema.org object (or array of objects). The serialized JSON has
+ * "<" escaped to "<" so a value can never break out of the <script> element
+ * (the standard safe-embedding guard for inline JSON-LD).
+ *
+ * Server-rendered, so the structured data is present in the initial HTML for
+ * crawlers and answer engines.
+ */
+export default function JsonLd({ data }: { data: object }) {
+  const json = JSON.stringify(data).replace(/</g, "\\u003c");
+  return (
+    <script
+      type="application/ld+json"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: json }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
Adds schema.org **`FAQPage`** structured data to `/faq` — the first item of the AEO/SEO RECON Tier-1 backlog. Enables FAQ rich results and direct answer-engine extraction.

## Implementation
- **`components/JsonLd.tsx`** — generic, server-rendered `<script type="application/ld+json">` with `<` escaped (`<`) so a value can't break out of the script element. Reusable for the remaining structured-data work (LocalBusiness, Service, BreadcrumbList…).
- **`app/faq/page.tsx`** — builds the `FAQPage` object from `content/faq.json` and renders it. The structured data is built from the **same content shown visibly on the page** (Google requires the FAQ content to be present), so they can't drift.

## Verification (built HTML)
- Valid JSON-LD, `@type: FAQPage`, **8 `Question` entries matching the 8 visible** FAQ items ✓
- `pnpm build` passes; server-rendered (present in initial HTML for crawlers) ✓

## Scope
- 2 files: new `JsonLd.tsx` + `app/faq/page.tsx`. No new deps, `pnpm-lock.yaml` untouched, no other routes. TS strict, no `any`.

## Backlog context
Next Tier-1 items (separate PRs): **LocalBusiness/Organization** (needs owner geo-coords + opening hours) and **per-page OpenGraph** (#48). Species `Dataset`/`ItemList` stays gated until the season data is verified.

Do not self-merge — for review.