### PR TITLE
feat(seo): per-page OpenGraph across all routes (AEO Tier-1)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,12 +1,17 @@
 import type { Metadata } from "next";
+import { pageOpenGraph } from "@/lib/seo";
 import Hero from "@/components/Hero";
 import CTASection from "@/components/CTASection";
 
+const TITLE = "About Us | SouthStar Charters";
+const DESCRIPTION =
+  "Meet the captain and crew behind SouthStar Charters. Learn about our boats, our mission, and why we are Staten Island's premier charter service.";
+
 export const metadata: Metadata = {
-  title: "About Us | SouthStar Charters",
-  description:
-    "Meet the captain and crew behind SouthStar Charters. Learn about our boats, our mission, and why we are Staten Island's premier charter service.",
+  title: TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: "/about" },
+  openGraph: pageOpenGraph({ path: "/about", title: TITLE, description: DESCRIPTION }),
 };
 
 export default function AboutPage() {

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,12 +1,17 @@
 import type { Metadata } from "next";
+import { pageOpenGraph } from "@/lib/seo";
 import ContactForm from "@/components/ContactForm";
 import { siteConfig } from "@/lib/site";
 
+const TITLE = "Contact Us | SouthStar Charters";
+const DESCRIPTION =
+  "Get in touch with SouthStar Charters to book your private harbor tour, fishing charter, or dive trip. Call (833) 464-8687 or send us a message.";
+
 export const metadata: Metadata = {
-  title: "Contact Us | SouthStar Charters",
-  description:
-    "Get in touch with SouthStar Charters to book your private harbor tour, fishing charter, or dive trip. Call (833) 464-8687 or send us a message.",
+  title: TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: "/contact" },
+  openGraph: pageOpenGraph({ path: "/contact", title: TITLE, description: DESCRIPTION }),
 };
 
 export default function ContactPage() {

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,13 +1,18 @@
 import type { Metadata } from "next";
+import { pageOpenGraph } from "@/lib/seo";
 import faqItems from "@/content/faq.json";
 import CTASection from "@/components/CTASection";
 import JsonLd from "@/components/JsonLd";
 
+const TITLE = "Frequently Asked Questions | SouthStar Charters";
+const DESCRIPTION =
+  "Find answers to common questions about SouthStar Charters, including what to bring, weather policies, fishing licenses, and booking information.";
+
 export const metadata: Metadata = {
-  title: "Frequently Asked Questions | SouthStar Charters",
-  description:
-    "Find answers to common questions about SouthStar Charters, including what to bring, weather policies, fishing licenses, and booking information.",
+  title: TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: "/faq" },
+  openGraph: pageOpenGraph({ path: "/faq", title: TITLE, description: DESCRIPTION }),
 };
 
 // FAQPage structured data, built from the same content rendered visibly below

--- a/app/fishing-charters/page.tsx
+++ b/app/fishing-charters/page.tsx
@@ -1,14 +1,19 @@
 import type { Metadata } from "next";
+import { pageOpenGraph } from "@/lib/seo";
 import Link from "next/link";
 import Hero from "@/components/Hero";
 import CTASection from "@/components/CTASection";
 import services from "@/content/services.json";
 
+const TITLE = "Fishing Charters — Inshore & Offshore | SouthStar Charters";
+const DESCRIPTION =
+  "Inshore, midshore, and offshore fishing charters along the New Jersey coast. Striped Bass, Tuna, Bluefish, and more. Year-round trips from Belmar and Barnegat Light, NJ.";
+
 export const metadata: Metadata = {
-  title: "Fishing Charters — Inshore & Offshore | SouthStar Charters",
-  description:
-    "Inshore, midshore, and offshore fishing charters along the New Jersey coast. Striped Bass, Tuna, Bluefish, and more. Year-round trips from Belmar and Barnegat Light, NJ.",
+  title: TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: "/fishing-charters" },
+  openGraph: pageOpenGraph({ path: "/fishing-charters", title: TITLE, description: DESCRIPTION }),
 };
 
 const { fishingCharters } = services;

--- a/app/gallery/layout.tsx
+++ b/app/gallery/layout.tsx
@@ -1,9 +1,17 @@
 import type { Metadata } from "next";
+import { pageOpenGraph } from "@/lib/seo";
 
 // The gallery page is a client component and cannot export `metadata`,
 // so its canonical URL is declared here in a route-level layout.
+const TITLE = "Photo Gallery | SouthStar Charters";
+const DESCRIPTION =
+  "Photos from SouthStar Charters — NYC harbor tours, New Jersey fishing charters, and life on the water from Staten Island, NY.";
+
 export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: "/gallery" },
+  openGraph: pageOpenGraph({ path: "/gallery", title: TITLE, description: DESCRIPTION }),
 };
 
 export default function GalleryLayout({

--- a/app/harbor-tours/page.tsx
+++ b/app/harbor-tours/page.tsx
@@ -1,13 +1,18 @@
 import type { Metadata } from "next";
+import { pageOpenGraph } from "@/lib/seo";
 import Hero from "@/components/Hero";
 import CTASection from "@/components/CTASection";
 import services from "@/content/services.json";
 
+const TITLE = "NYC Harbor Sightseeing Tours | SouthStar Charters";
+const DESCRIPTION =
+  "Experience the Statue of Liberty and the New York skyline on a private luxury yacht. VIP-style harbor tours for up to 13 guests from Staten Island, NY.";
+
 export const metadata: Metadata = {
-  title: "NYC Harbor Sightseeing Tours | SouthStar Charters",
-  description:
-    "Experience the Statue of Liberty and the New York skyline on a private luxury yacht. VIP-style harbor tours for up to 13 guests from Staten Island, NY.",
+  title: TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: "/harbor-tours" },
+  openGraph: pageOpenGraph({ path: "/harbor-tours", title: TITLE, description: DESCRIPTION }),
 };
 
 const { harborTours } = services;

--- a/app/rates/page.tsx
+++ b/app/rates/page.tsx
@@ -1,13 +1,18 @@
 import type { Metadata } from "next";
+import { pageOpenGraph } from "@/lib/seo";
 import Link from "next/link";
 import ratesData from "@/content/rates.json";
 import CTASection from "@/components/CTASection";
 
+const TITLE = "Charter Rates & Pricing | SouthStar Charters";
+const DESCRIPTION =
+  "View our full list of charter rates for offshore, midshore, and inshore fishing, beach trips, and spearfishing. Transparent pricing from SouthStar Charters.";
+
 export const metadata: Metadata = {
-  title: "Charter Rates & Pricing | SouthStar Charters",
-  description:
-    "View our full list of charter rates for offshore, midshore, and inshore fishing, beach trips, and spearfishing. Transparent pricing from SouthStar Charters.",
+  title: TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: "/rates" },
+  openGraph: pageOpenGraph({ path: "/rates", title: TITLE, description: DESCRIPTION }),
 };
 
 export default function RatesPage() {

--- a/app/reviews/page.tsx
+++ b/app/reviews/page.tsx
@@ -1,12 +1,17 @@
 import type { Metadata } from "next";
+import { pageOpenGraph } from "@/lib/seo";
 import testimonials from "@/content/testimonials.json";
 import CTASection from "@/components/CTASection";
 
+const TITLE = "Customer Reviews | SouthStar Charters";
+const DESCRIPTION =
+  "Read what our guests have to say about their experience with SouthStar Charters. Real reviews from real customers.";
+
 export const metadata: Metadata = {
-  title: "Customer Reviews | SouthStar Charters",
-  description:
-    "Read what our guests have to say about their experience with SouthStar Charters. Real reviews from real customers.",
+  title: TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: "/reviews" },
+  openGraph: pageOpenGraph({ path: "/reviews", title: TITLE, description: DESCRIPTION }),
 };
 
 function StarRating({ rating }: { rating: number }) {

--- a/app/species/page.tsx
+++ b/app/species/page.tsx
@@ -1,21 +1,19 @@
 import type { Metadata } from "next";
+import { pageOpenGraph } from "@/lib/seo";
 import SeasonCalendar from "@/components/SeasonCalendar";
 import CaptainTrustPanel from "@/components/CaptainTrustPanel";
 import CTASection from "@/components/CTASection";
 import { species } from "@/lib/data/speciesSeasons";
 
+const TITLE = "North Atlantic Fish Species & Seasons | SouthStar Charters";
+const DESCRIPTION =
+  "Target species in North Atlantic federal, interstate, and state waters, with a month-by-month season calendar. Seasons differ by jurisdiction — always confirm current regulations before fishing.";
+
 export const metadata: Metadata = {
-  title: "North Atlantic Fish Species & Seasons | SouthStar Charters",
-  description:
-    "Target species in North Atlantic federal, interstate, and state waters, with a month-by-month season calendar. Seasons differ by jurisdiction — always confirm current regulations before fishing.",
+  title: TITLE,
+  description: DESCRIPTION,
   alternates: { canonical: "/species" },
-  openGraph: {
-    type: "website",
-    url: "/species",
-    title: "North Atlantic Fish Species & Seasons | SouthStar Charters",
-    description:
-      "Target species in North Atlantic waters with a dynamic, month-by-month season calendar across federal, interstate, and state jurisdictions.",
-  },
+  openGraph: pageOpenGraph({ path: "/species", title: TITLE, description: DESCRIPTION }),
 };
 
 // Re-render hourly so the "in season now" status stays current as dates pass,

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { siteConfig } from "@/lib/site";
+
+/**
+ * Build a per-page OpenGraph block with shared site defaults.
+ *
+ * Next.js shallow-merges metadata, so a page that sets `openGraph` replaces the
+ * root layout's openGraph entirely (it is not deep-merged). This helper keeps
+ * the shared bits (site name, image, type, locale) consistent so every page can
+ * declare its own url/title/description without dropping the image.
+ *
+ * `path` is relative (e.g. "/about") and resolves against `metadataBase`.
+ */
+export function pageOpenGraph(opts: {
+  path: string;
+  title: string;
+  description: string;
+}): Metadata["openGraph"] {
+  return {
+    type: "website",
+    locale: "en_US",
+    url: opts.path,
+    siteName: siteConfig.name,
+    title: opts.title,
+    description: opts.description,
+    images: [{ url: siteConfig.ogImage, width: 1200, height: 630 }],
+  };
+}


### PR DESCRIPTION
## Summary
Gives every route its **own** OpenGraph block. Previously only the root layout and `/species` set `openGraph`, so all other pages inherited the **homepage's** OG url/title/description when shared on social/answer engines. Resolves the residual OG item noted alongside the canonical fix (#48).

## Implementation
- **`lib/seo.ts`** — `pageOpenGraph()` helper: shared OG defaults (site name, image, type, locale) + per-page url/title/description. Documents that Next.js **shallow-merges** metadata, so a page's `openGraph` replaces (not deep-merges) the layout's — which is why every page must carry the image itself.
- **7 server pages + gallery layout** — own `openGraph`; `title`/`description` extracted to consts so OG and meta can't drift.
- **`/species`** — `openGraph` now includes the shared image (it previously set OG without one — a small regression from #51, fixed here).
- **`/gallery`** — gains a proper `title`/`description` (it had neither) plus OG.
- **Home** — keeps inheriting the layout OG (correct for the homepage).

## Verification (built HTML)
Each route emits its own `og:url` + `og:image`:

| Route | og:url |
|---|---|
| /about … /species | `…/about`, `…/contact`, `…/faq`, `…/rates`, `…/reviews`, `…/harbor-tours`, `…/fishing-charters`, `…/gallery`, `…/species` |
| / (home) | `…/` (unchanged, inherits layout) |

`pnpm build` passes.

## Scope
- `lib/seo.ts` (new) + 9 route files. No new deps, `pnpm-lock.yaml`/`package.json` untouched, no component/logic changes. TS strict, no `any`.

## Tier-1 status
This completes Tier-1 items 1 (FAQPage, merged #53) and 3 (this). Remaining: **LocalBusiness/Organization** — needs your geo-coords + opening hours.

Do not self-merge — for review.