### PR TITLE
feat(locations): Wyckoff NAP anchor, departure points, national reach + JSON-LD

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { pageOpenGraph } from "@/lib/seo";
 import ContactForm from "@/components/ContactForm";
 import { siteConfig } from "@/lib/site";
@@ -15,7 +16,7 @@ export const metadata: Metadata = {
 };
 
 export default function ContactPage() {
-  const { contact, social } = siteConfig;
+  const { contact, social, locations } = siteConfig;
 
   return (
     <>
@@ -43,7 +44,9 @@ export default function ContactPage() {
 
             <dl className="mt-8 space-y-4 text-sm">
               <div>
-                <dt className="font-semibold text-slate-900">Address</dt>
+                <dt className="font-semibold text-slate-900">
+                  Main Office (NJ / NY)
+                </dt>
                 <dd className="text-slate-600">
                   {contact.address.street}, {contact.address.city},{" "}
                   {contact.address.state} {contact.address.zip}
@@ -115,6 +118,129 @@ export default function ContactPage() {
             </h2>
             <ContactForm />
           </div>
+        </div>
+      </section>
+
+      {/* ── Where We Fish — Locations ─────────────────────────────────── */}
+      <section className="bg-slate-50 px-4 py-16 sm:py-20">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-3xl font-bold tracking-tight text-slate-900">
+            Where We Fish
+          </h2>
+          <p className="mt-3 max-w-2xl text-slate-600">
+            Our home base is in {locations.primary.address.city},{" "}
+            {locations.primary.address.state}. Trips run from two marinas, each
+            suited to a different fishery. Booking for every trip is the same
+            toll-free line —{" "}
+            <a
+              href={`tel:${contact.phoneTel}`}
+              className="font-medium text-sky-600 hover:text-sky-700"
+            >
+              {contact.phone}
+            </a>
+            . The marina numbers below reach the docks themselves and are not for
+            booking.
+          </p>
+
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            {/* Primary / office (sole NAP anchor) */}
+            <div className="rounded-xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
+              <p className="text-xs font-semibold uppercase tracking-wide text-sky-700">
+                {locations.primary.role}
+              </p>
+              <h3 className="mt-1 text-lg font-bold text-slate-900">
+                {locations.primary.name}
+              </h3>
+              <address className="mt-2 text-sm not-italic text-slate-600">
+                {locations.primary.address.street}
+                <br />
+                {locations.primary.address.city},{" "}
+                {locations.primary.address.state}{" "}
+                {locations.primary.address.zip}
+              </address>
+              <a
+                href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+                  `${locations.primary.address.street}, ${locations.primary.address.city}, ${locations.primary.address.state} ${locations.primary.address.zip}`,
+                )}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-3 inline-block text-sm font-medium text-sky-600 hover:text-sky-700"
+              >
+                View on Google Maps &rarr;
+              </a>
+            </div>
+
+            {/* Departure points (places operated from — not separate businesses) */}
+            {locations.departurePoints.map((dp) => (
+              <div
+                key={dp.name}
+                className="rounded-xl bg-white p-6 shadow-sm ring-1 ring-slate-200"
+              >
+                <p className="text-xs font-semibold uppercase tracking-wide text-sky-700">
+                  {dp.role}
+                </p>
+                <h3 className="mt-1 text-lg font-bold text-slate-900">
+                  {dp.name}
+                </h3>
+                <address className="mt-2 text-sm not-italic text-slate-600">
+                  {dp.address.street}
+                  <br />
+                  {dp.address.city}, {dp.address.state} {dp.address.zip}
+                </address>
+                <p className="mt-3 text-sm leading-relaxed text-slate-700">
+                  {dp.fishery}
+                </p>
+                <Link
+                  href={dp.speciesHref}
+                  className="mt-2 inline-block text-sm font-medium text-sky-600 hover:text-sky-700"
+                >
+                  View species &amp; seasons &rarr;
+                </Link>
+                <p className="mt-4 text-xs text-slate-500">
+                  <span className="font-semibold text-slate-600">
+                    Marina line:{" "}
+                  </span>
+                  <a
+                    href={`tel:+1${dp.marinaPhone.replace(/\D/g, "")}`}
+                    className="text-slate-600 underline"
+                  >
+                    {dp.marinaPhone}
+                  </a>{" "}
+                  <span className="text-slate-400">
+                    (dock info — not for booking)
+                  </span>
+                </p>
+                <a
+                  href={`https://www.google.com/maps/search/?api=1&query=${dp.geo.lat},${dp.geo.lng}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-2 inline-block text-sm font-medium text-sky-600 hover:text-sky-700"
+                >
+                  View on Google Maps &rarr;
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── National Reach ───────────────────────────────────────────── */}
+      <section className="px-4 py-16 sm:py-20">
+        <div className="mx-auto max-w-3xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-slate-900">
+            National Reach
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-lg leading-relaxed text-slate-600">
+            SouthStar Charters operates from our NJ/NY home waters and serves
+            anglers across the country. Wherever you want to fish, we go where
+            the fish are.
+          </p>
+          <a
+            href={`tel:${contact.phoneTel}`}
+            className="mt-8 inline-block rounded-md bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition-colors hover:bg-sky-700"
+          >
+            Call {contact.phone} to Book
+          </a>
         </div>
       </section>
     </>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,9 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import JsonLd from "@/components/JsonLd";
 import { siteConfig } from "@/lib/site";
+import { localBusinessJsonLd, serviceJsonLd } from "@/lib/seo";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -57,6 +59,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.variable} font-sans antialiased`}>
+        <JsonLd data={[localBusinessJsonLd(), serviceJsonLd()]} />
         <Header />
         <main className="min-h-screen">{children}</main>
         <Footer />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { siteConfig } from "@/lib/site";
 
 export default function Footer() {
-  const { contact, social, nav } = siteConfig;
+  const { contact, social, nav, locations } = siteConfig;
 
   return (
     <footer className="border-t border-slate-200 bg-slate-900 text-slate-300">
@@ -64,6 +64,12 @@ export default function Footer() {
                 >
                   {contact.email}
                 </a>
+              </p>
+              <p className="pt-1 text-xs text-slate-400">
+                Departure points:{" "}
+                {locations.departurePoints
+                  .map((d) => `${d.name} (${d.address.city}, ${d.address.state})`)
+                  .join(" · ")}
               </p>
             </address>
           </div>

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -26,3 +26,61 @@ export function pageOpenGraph(opts: {
     images: [{ url: siteConfig.ogImage, width: 1200, height: 630 }],
   };
 }
+
+/**
+ * LocalBusiness structured data — the single business anchor, sourced from
+ * siteConfig (Wyckoff primary NAP). LocalBusiness is a subtype of Organization,
+ * so this one object also carries the Organization signals (name, url, image,
+ * sameAs).
+ *
+ * `geo` is intentionally OMITTED: the verified Business Profile data provides no
+ * coordinate for the Wyckoff anchor, and a coordinate must not be invented (a
+ * wrong one misplaces the business in maps). The marinas have coordinates, but
+ * they are departure points, not this LocalBusiness.
+ *
+ * `openingHours` is omitted for the same reason — no verified hours were provided.
+ */
+export function localBusinessJsonLd() {
+  const { contact, social } = siteConfig;
+  return {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "@id": `${siteConfig.url}/#business`,
+    name: siteConfig.name,
+    description: siteConfig.description,
+    url: siteConfig.url,
+    image: `${siteConfig.url}${siteConfig.ogImage}`,
+    telephone: contact.phoneTel,
+    email: contact.email,
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: contact.address.street,
+      addressLocality: contact.address.city,
+      addressRegion: contact.address.state,
+      postalCode: contact.address.zip,
+      addressCountry: "US",
+    },
+    sameAs: [social.facebook, social.instagram],
+  };
+}
+
+/**
+ * Service structured data — captures the verified national service area without
+ * inventing fake per-location LocalBusinesses. areaServed is United States /
+ * North America only (the verified profile shows a North America boundary — NOT
+ * global / international).
+ */
+export function serviceJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    name: "Fishing Charters & Harbor Tours",
+    serviceType: "Fishing charter",
+    provider: { "@id": `${siteConfig.url}/#business` },
+    areaServed: [
+      { "@type": "Country", name: "United States" },
+      { "@type": "Place", name: "North America" },
+    ],
+    url: `${siteConfig.url}/fishing-charters`,
+  };
+}

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -9,15 +9,67 @@ export const siteConfig = {
   ogImage: "/images/gallery/southstar_gallery_1.webp",
 
   contact: {
-    phone: "(833) 464-8687",
+    phone: "(833) 464-8687", // national toll-free booking line
     phoneTel: "+18334648687",
     email: "info@southstarchartersnj.com",
+    // Primary NAP anchor = the verified Wyckoff Business Profile.
     address: {
-      street: "180 Madison Ave",
-      city: "Staten Island",
-      state: "NY",
-      zip: "10308",
+      street: "431 Lafayette Ave",
+      city: "Wyckoff",
+      state: "NJ",
+      zip: "07481",
     },
+  },
+
+  /**
+   * Locations. Wyckoff is the canonical NAP / sole LocalBusiness anchor; the
+   * marinas are DEPARTURE POINTS we operate from (not separate businesses).
+   * Marina phones are departure-point info only — booking is the toll-free line
+   * above. Coordinates come from the owner's verified Google Business profiles.
+   * (No Wyckoff coordinate is published, so the anchor carries no geo.)
+   */
+  locations: {
+    primary: {
+      name: "SouthStar Charters NJ / NY",
+      role: "Main office",
+      address: {
+        street: "431 Lafayette Ave",
+        city: "Wyckoff",
+        state: "NJ",
+        zip: "07481",
+      },
+    },
+    departurePoints: [
+      {
+        name: "Bayview Harbor",
+        role: "Departure point",
+        address: {
+          street: "1301 Bayview Ave",
+          city: "Barnegat Light",
+          state: "NJ",
+          zip: "08006",
+        },
+        geo: { lat: 39.7543491, lng: -74.1119982 },
+        marinaPhone: "(609) 494-7450",
+        speciesHref: "/species",
+        fishery:
+          "Our primary offshore canyon and HMS grounds — bluefin, yellowfin, bigeye, albacore, mahi, wahoo, and swordfish — plus seasonal striped bass.",
+      },
+      {
+        name: "Atlantis Marina",
+        role: "Departure point",
+        address: {
+          street: "183 Mansion Ave",
+          city: "Staten Island",
+          state: "NY",
+          zip: "10308",
+        },
+        geo: { lat: 40.5435574, lng: -74.1414529 },
+        marinaPhone: "(718) 966-9700",
+        speciesHref: "/species#striped-bass",
+        fishery: "Seasonal striped bass.",
+      },
+    ],
   },
 
   social: {


### PR DESCRIPTION
## Summary
Aligns the site's location identity with the owner's **verified** Google Business profiles: Wyckoff as the sole NAP/LocalBusiness anchor, Bayview Harbor + Atlantis Marina as departure points mapped to their fishery, national (US/North America) reach as a Service claim, and the toll-free line as the booking number.

## ⚠️ Reconciliation (pre-flight findings)
- **There was no "Atlantis" on the site to reconcile** — the only Staten Island data was `lib/site.ts: street "180 Madison Ave"`, serving as the *sole primary address*. It **differed** from your verified `183 Mansion Ave`. Per scope item 6 I flagged it before changing; with your go, the wrong `180 Madison Ave` is replaced by **Wyckoff (anchor)** + **Atlantis at the verified 183 Mansion Ave**.
- Flagged separately (not touched): `content/faq.json:16` names *different* departure marinas ("Belmar Shark River"; "Light House Marina, Barnegat Light") — your call to reconcile.

## What changed
- **`lib/site.ts`** — primary NAP → verified **Wyckoff, 431 Lafayette Ave, NJ 07481**. New `locations`: primary + `departurePoints[]` (Bayview Harbor `39.7543491,-74.1119982` / `(609) 494-7450`; Atlantis Marina `40.5435574,-74.1414529` / `(718) 966-9700`) with departure-labeled marina phones + fishery + species link.
- **`app/contact/page.tsx`** — "Where We Fish" section: all 3 locations as crawlable text + Google Maps links; marina numbers labelled **"dock info — not for booking"**; fishery → species page (Bayview → `/species`, Atlantis → `/species#striped-bass`), **no season dates restated**. "National Reach" section with your exact copy (US/North America, **not international**).
- **`components/Footer.tsx`** — Wyckoff primary NAP + departure-points line.
- **`lib/seo.ts` + `app/layout.tsx`** — sitewide JSON-LD: one **LocalBusiness** (Wyckoff; **geo omitted** — no verified coordinate, inventing nothing; **hours omitted** — none verified) + one **Service** (`areaServed` = United States / North America). Departure points are **not** competing LocalBusinesses.

## Verification (built HTML)
- LocalBusiness: name + `431 Lafayette Ave, Wyckoff, NJ 07481`, geo omitted, 2 `sameAs` ✓
- Service: `areaServed` = `["United States","North America"]`, `provider` → `/#business` ✓
- Contact page: all addresses/coords/phones exact; "not for booking" labels present; Maps links; species links; National Reach copy ✓
- Booking `(833) 464-8687` on CTAs; **no** `180 Madison`, **no** international claim, **no** "Atlantic Marina"/Ellis St ✓
- `pnpm build` passes; entity-separation clean (no mortgage identity added)

## Constraints honored
Verified data exact; marina numbers = departure labels only; one branch; no `pnpm-lock.yaml`; no unrelated routes; TS strict; Tailwind.

Do not self-merge — for review.