### PR TITLE
fix/feat: reconcile all departure & pickup locations (FAQ + contact)

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -129,8 +129,9 @@ export default function ContactPage() {
           </h2>
           <p className="mt-3 max-w-2xl text-slate-600">
             Our home base is in {locations.primary.address.city},{" "}
-            {locations.primary.address.state}. Trips run from two marinas, each
-            suited to a different fishery. Booking for every trip is the same
+            {locations.primary.address.state}. Trips run from several marinas
+            along the New Jersey and New York coast, each suited to a different
+            fishery. Booking for every trip is the same
             toll-free line —{" "}
             <a
               href={`tel:${contact.phoneTel}`}
@@ -221,6 +222,18 @@ export default function ContactPage() {
               </div>
             ))}
           </div>
+
+          {locations.pickupLocations.length > 0 && (
+            <p className="mt-6 text-sm text-slate-500">
+              <span className="font-semibold text-slate-600">
+                Additional pickup locations:
+              </span>{" "}
+              {locations.pickupLocations
+                .map((p) => `${p.name} (${p.city}, ${p.state})`)
+                .join(" · ")}
+              . Contact us to arrange the pickup point for your trip.
+            </p>
+          )}
         </div>
       </section>
 

--- a/content/faq.json
+++ b/content/faq.json
@@ -13,7 +13,7 @@
   },
   {
     "question": "Where do charters depart from?",
-    "answer": "Harbor tours depart from Staten Island, NY. Fishing and dive charters depart from Belmar Shark River, New Jersey, or Light House Marina in Barnegat Light, NJ, depending on the trip."
+    "answer": "Harbor tours depart from Staten Island, NY. Fishing and dive charters depart from Bayview Harbor or Light House Marina in Barnegat Light, NJ; Atlantis Marina in Staten Island, NY; or the Shark River in Belmar, NJ, depending on the trip. Contact us to confirm the departure point for your charter."
   },
   {
     "question": "Do I need a fishing license?",

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -70,6 +70,15 @@ export const siteConfig = {
         fishery: "Seasonal striped bass.",
       },
     ],
+    /**
+     * Additional pickup locations the owner operates from but for which no
+     * verified coordinates or marina phone are published. They carry name +
+     * town only — no map link, no phone, nothing invented. Not NAP anchors.
+     */
+    pickupLocations: [
+      { name: "Light House Marina", city: "Barnegat Light", state: "NJ" },
+      { name: "Shark River", city: "Belmar", state: "NJ" },
+    ],
   },
 
   social: {


### PR DESCRIPTION
## Summary
Reconciles every departure/pickup location across the site after #55. All four are real (owner-confirmed); only two have verified structured data.

**Commit 1 — FAQ (`content/faq.json`):** the "Where do charters depart from?" answer now lists all four — Bayview Harbor + Light House Marina (Barnegat Light, NJ), Atlantis Marina (Staten Island, NY), Shark River (Belmar, NJ) — owner names preserved, FAQPage JSON-LD auto-updated.

**Commit 2 — pickup locations (`lib/site.ts`, `app/contact/page.tsx`):** Light House Marina and Shark River are real but have **no verified coordinates/phone**, so they're added as `pickupLocations` (name + town only) and shown on the contact page as a text-only "Additional pickup locations" line — **no map link, no phone, nothing invented**.

## Verified vs unverified (the §3 line)
| Location | Data | Contact page |
|---|---|---|
| Bayview Harbor, Atlantis Marina | verified address + coords + phone | full cards w/ map links |
| Light House Marina, Shark River | name + town only (unverified) | text-only "pickup locations" |

## Verification (built HTML)
- FAQ lists all four; pickup line renders "Light House Marina (Barnegat Light, NJ) · Shark River (Belmar, NJ)" as text ✓
- Maps links remain only for the 3 verified locations (Wyckoff, Bayview, Atlantis); pickup marinas have **no** map link/phone ✓
- `pnpm build` passes; nothing invented; no mortgage identity.

## Scope
`content/faq.json`, `lib/site.ts`, `app/contact/page.tsx`. No new deps, no `pnpm-lock.yaml`.

Do not self-merge — for review.