### PR TITLE
feat(species): verified 2026 NJ seasons for state/interstate species

### DIFF
--- a/app/species/page.tsx
+++ b/app/species/page.tsx
@@ -49,8 +49,10 @@ export default function SpeciesPage() {
             governing authority before fishing.
           </p>
           <p className="mt-2 text-xs text-amber-800">
-            The dates and limits below are unverified placeholders pending owner
-            confirmation — they are not current regulatory data.
+            The inshore species below show 2026 New Jersey recreational rules
+            (NJ Division of Fish &amp; Wildlife). Offshore / HMS species are still
+            marked &ldquo;unverified placeholder&rdquo; and are not current
+            regulatory data. Always confirm with the governing authority.
           </p>
         </div>
       </section>

--- a/lib/data/speciesSeasons.ts
+++ b/lib/data/speciesSeasons.ts
@@ -2,8 +2,13 @@
  * North Atlantic Fish Species & Seasons — OWNER-CONTROLLED DATA
  * ============================================================================
  *
- * ⚠️  EVERY season window, size limit, and bag limit in this file is an
- *     UNFILLED PLACEHOLDER. There is NO real regulatory data here.
+ * ⚠️  MIXED STATE. The state/interstate species (striped bass, summer flounder,
+ *     bluefish, weakfish, false albacore, Atlantic bonito) carry verified 2026
+ *     New Jersey recreational rules, sourced from the NJ DEP "Attention Anglers"
+ *     2026 summary (https://dep.nj.gov/njfw/fishing/marine/seasons-and-regulations/,
+ *     dated March 2026) and confirmed by the owner — those entries have
+ *     `verify: false`. The offshore / HMS species are STILL UNFILLED PLACEHOLDERS
+ *     (`verify: true`), pending a schema decision and verification.
  *
  *     Placeholder windows use the SENTINEL value "00-00" (an impossible date) so
  *     they are self-evidently fake at the data layer — not just behind a UI
@@ -95,7 +100,7 @@ export interface Species {
   waterType: "inshore" | "offshore" | "both";
   permitRequired: boolean;
   seasons: Season[];
-  verify: true;
+  verify: boolean;
   /** Optional NOAA public-domain image; rendered only when rightsVerified. */
   image?: SpeciesImage;
   /**
@@ -149,10 +154,26 @@ export const species: Species[] = [
     waterType: "inshore",
     permitRequired: false,
     seasons: [
-      pending("interstate", "PLACEHOLDER — ASMFC striped bass plan, pending verification"),
-      pending("state", "PLACEHOLDER — NJ state waters, pending verification"),
+      {
+        jurisdiction: "interstate",
+        openDate: "01-01",
+        closeDate: "12-31",
+        minSizeInches: 28,
+        bagLimit: 1,
+        notes:
+          "Slot 28–31 in (1 fish), ASMFC rule as implemented by NJ. Harvest is prohibited in federal waters (>3 mi).",
+      },
+      {
+        jurisdiction: "state",
+        openDate: "01-01",
+        closeDate: "12-31",
+        minSizeInches: 28,
+        bagLimit: 1,
+        notes:
+          "Slot 28–31 in (1 fish), NJ ocean waters 0–3 mi, no closed season. See the NJ Marine Digest for the Bonus Program, circle-hook and gaff rules.",
+      },
     ],
-    verify: true,
+    verify: false,
   },
   {
     commonName: "Summer Flounder (Fluke)",
@@ -170,10 +191,25 @@ export const species: Species[] = [
     waterType: "both",
     permitRequired: false,
     seasons: [
-      pending("federal", "PLACEHOLDER — federal window may differ from state, pending verification"),
-      pending("state", "PLACEHOLDER — NJ state window, pending verification"),
+      {
+        jurisdiction: "federal",
+        openDate: "05-04",
+        closeDate: "09-25",
+        minSizeInches: 18,
+        bagLimit: 3,
+        notes: "Follows the NJ-implemented recreational measures in federal waters.",
+      },
+      {
+        jurisdiction: "state",
+        openDate: "05-04",
+        closeDate: "09-25",
+        minSizeInches: 18,
+        bagLimit: 3,
+        notes:
+          "NJ ocean rule. Special areas differ: Delaware Bay 3 @ 17 in; Island Beach State Park 2 @ 16 in.",
+      },
     ],
-    verify: true,
+    verify: false,
   },
   {
     commonName: "Bluefish",
@@ -190,8 +226,17 @@ export const species: Species[] = [
       "The stock is not overfished and is not subject to overfishing.",
     waterType: "both",
     permitRequired: false,
-    seasons: [pending("interstate", "PLACEHOLDER — ASMFC bluefish plan, pending verification")],
-    verify: true,
+    seasons: [
+      {
+        jurisdiction: "interstate",
+        openDate: "01-01",
+        closeDate: "12-31",
+        bagLimit: 7,
+        notes:
+          "7 fish on a for-hire vessel; 5 for private/shore anglers. No minimum size.",
+      },
+    ],
+    verify: false,
   },
   {
     commonName: "Weakfish",
@@ -200,10 +245,23 @@ export const species: Species[] = [
     waterType: "inshore",
     permitRequired: false,
     seasons: [
-      pending("interstate", "PLACEHOLDER — ASMFC weakfish plan, pending verification"),
-      pending("state", "PLACEHOLDER — NJ state waters, pending verification"),
+      {
+        jurisdiction: "interstate",
+        openDate: "01-01",
+        closeDate: "12-31",
+        minSizeInches: 13,
+        bagLimit: 1,
+        notes: "ASMFC rule as implemented by NJ.",
+      },
+      {
+        jurisdiction: "state",
+        openDate: "01-01",
+        closeDate: "12-31",
+        minSizeInches: 13,
+        bagLimit: 1,
+      },
     ],
-    verify: true,
+    verify: false,
   },
   {
     commonName: "False Albacore (Little Tunny)",
@@ -211,8 +269,15 @@ export const species: Species[] = [
     slug: "false-albacore",
     waterType: "inshore",
     permitRequired: false,
-    seasons: [pending("state", "PLACEHOLDER — confirm NJ status, pending verification")],
-    verify: true,
+    seasons: [
+      {
+        jurisdiction: "state",
+        openDate: "01-01",
+        closeDate: "12-31",
+        notes: "No NJ size or possession limit (not listed in the NJ recreational summary).",
+      },
+    ],
+    verify: false,
   },
   {
     commonName: "Atlantic Bonito",
@@ -220,8 +285,15 @@ export const species: Species[] = [
     slug: "atlantic-bonito",
     waterType: "inshore",
     permitRequired: false,
-    seasons: [pending("state", "PLACEHOLDER — confirm NJ status, pending verification")],
-    verify: true,
+    seasons: [
+      {
+        jurisdiction: "state",
+        openDate: "01-01",
+        closeDate: "12-31",
+        notes: "No NJ size or possession limit (not listed in the NJ recreational summary).",
+      },
+    ],
+    verify: false,
   },
 
   // ── Offshore canyons — HMS species are federally managed & permit-required ──


### PR DESCRIPTION
## Summary
Fills the placeholder season data for the **six state/interstate species** with **verified 2026 New Jersey recreational rules**, sourced from the [NJ DEP "Attention Anglers" 2026 summary](https://dep.nj.gov/njfw/fishing/marine/seasons-and-regulations/) (March 2026) and confirmed by the owner. The eight offshore/HMS species **remain placeholders** (gated on the schema-extension decision).

| Species | Min size | Bag | Season |
|---|---|---|---|
| Striped Bass | slot **28–31″** | 1 | NJ ocean 0–3 mi year-round; **federal >3 mi closed** |
| Summer Flounder (Fluke) | 18″ | 3 | **May 4 – Sept 25** |
| Bluefish | none | **7** for-hire (5 private) | year-round |
| Weakfish | 13″ | 1 | year-round |
| False Albacore | — | — | unregulated (year-round) |
| Atlantic Bonito | — | — | unregulated (year-round) |

Slot limits, the federal striped-bass closure, fluke special-area exceptions, and the bluefish for-hire/private split are captured in each season's `notes` (the schema holds one `minSizeInches`/`bagLimit`).

## Mechanics
- `verify` type widened `true` → `boolean`; the six species now `verify: false` (badge gone, real in/out status shows); HMS stay `verify: true` with `00-00` sentinels.
- Data-file header + species-page disclaimer updated to reflect the **mixed** state (NJ-verified inshore vs. pending HMS).

## Verification (built HTML)
- "Unverified placeholder" badge + "Dates pending verification" now only on the 8 HMS species (16 = 8×2 RSC) ✓
- Six species render real seasons + size/bag + in/out status (e.g. fluke in-season now, striped-bass slot 28–31, bluefish 7 for-hire) ✓
- `pnpm build` passes; logic unit-checked (fluke in/out by date; HMS still "pending").

## Scope / notes
- Files: `lib/data/speciesSeasons.ts`, `app/species/page.tsx`. No deps, no `pnpm-lock.yaml`.
- NJ's own disclaimer applies: *"summary… not the full law… at time of publication"* — re-check at season changes.
- Installed `poppler` locally (authorized) to read the NJ PDFs; no repo impact.

Do not self-merge — for review.