### PR TITLE
feat(species): limitNote schema + 6 HMS species filled (sourced, flagged)

### DIFF
--- a/app/species/page.tsx
+++ b/app/species/page.tsx
@@ -49,10 +49,11 @@ export default function SpeciesPage() {
             governing authority before fishing.
           </p>
           <p className="mt-2 text-xs text-amber-800">
-            The inshore species below show 2026 New Jersey recreational rules
-            (NJ Division of Fish &amp; Wildlife). Offshore / HMS species are still
-            marked &ldquo;unverified placeholder&rdquo; and are not current
-            regulatory data. Always confirm with the governing authority.
+            Inshore species show 2026 New Jersey recreational rules (NJ Division
+            of Fish &amp; Wildlife). Offshore / HMS species show NOAA HMS values
+            marked &ldquo;Unverified — confirm with NOAA&rdquo;; Mahi and Wahoo
+            remain unverified placeholders. Always confirm with the governing
+            authority before fishing.
           </p>
         </div>
       </section>

--- a/components/SeasonCalendar.tsx
+++ b/components/SeasonCalendar.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/data/speciesSeasons";
 import {
   getSeasonStatus,
+  isPlaceholderSeason,
   monthsInWindow,
   MONTH_ABBREVIATIONS,
 } from "@/lib/seasons";
@@ -16,11 +17,14 @@ interface SeasonCalendarProps {
   referenceDate?: Date;
 }
 
-/** Small amber badge flagging that the underlying data is an unverified placeholder. */
-function UnverifiedBadge() {
+/**
+ * Small amber badge for unverified data. "placeholder" = no real values yet
+ * (sentinel windows); otherwise the values are sourced but not owner-confirmed.
+ */
+function UnverifiedBadge({ placeholder }: { placeholder: boolean }) {
   return (
     <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 ring-1 ring-amber-200">
-      Unverified placeholder
+      {placeholder ? "Unverified placeholder" : "Unverified — confirm with NOAA"}
     </span>
   );
 }
@@ -64,7 +68,11 @@ export default function SeasonCalendar({
                 NOAA HMS permit required
               </span>
             )}
-            {sp.verify && <UnverifiedBadge />}
+            {sp.verify && (
+              <UnverifiedBadge
+                placeholder={sp.seasons.some(isPlaceholderSeason)}
+              />
+            )}
           </div>
 
           {/* Per-jurisdiction seasons */}
@@ -141,7 +149,9 @@ export default function SeasonCalendar({
                             Bag limit
                           </dt>
                           <dd className="text-slate-800">
-                            {season.bagLimit != null ? `${season.bagLimit}` : "—"}
+                            {season.bagLimit != null
+                              ? `${season.bagLimit}${season.limitNote ? ` (${season.limitNote})` : ""}`
+                              : (season.limitNote ?? "—")}
                           </dd>
                         </div>
                         <div className="col-span-2 sm:col-span-1">

--- a/lib/data/speciesSeasons.ts
+++ b/lib/data/speciesSeasons.ts
@@ -7,8 +7,11 @@
  *     New Jersey recreational rules, sourced from the NJ DEP "Attention Anglers"
  *     2026 summary (https://dep.nj.gov/njfw/fishing/marine/seasons-and-regulations/,
  *     dated March 2026) and confirmed by the owner — those entries have
- *     `verify: false`. The offshore / HMS species are STILL UNFILLED PLACEHOLDERS
- *     (`verify: true`), pending a schema decision and verification.
+ *     `verify: false`. Most offshore / HMS species (bluefin, yellowfin, bigeye,
+ *     albacore, marlin, swordfish) now carry NOAA HMS recreational values but are
+ *     still SOURCED-NOT-CONFIRMED (`verify: true`) pending the owner's check
+ *     against the NOAA HMS Compliance Guide. Mahi and Wahoo remain UNFILLED
+ *     sentinel placeholders (`verify: true`) — values could not be sourced.
  *
  *     Placeholder windows use the SENTINEL value "00-00" (an impossible date) so
  *     they are self-evidently fake at the data layer — not just behind a UI
@@ -72,6 +75,8 @@ export interface Season {
   closeDate: string; // "MM-DD" or PLACEHOLDER_DATE
   minSizeInches?: number;
   bagLimit?: number;
+  /** Free-text limit when it is not a single per-person integer (e.g. "No limit", per-vessel caps, quotas). */
+  limitNote?: string;
   notes?: string;
 }
 
@@ -312,7 +317,17 @@ export const species: Species[] = [
       "Western Atlantic bluefin tuna is not subject to overfishing; its overfished status is unknown. It is managed under a rebuilding plan.",
     waterType: "offshore",
     permitRequired: true, // NOAA HMS
-    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS, pending verification")],
+    seasons: [
+      {
+        jurisdiction: "federal",
+        openDate: "01-01",
+        closeDate: "12-31",
+        minSizeInches: 27,
+        limitNote:
+          "Category system: 2/vessel/day (27–<73 in); trophy 73 in+ is 1/vessel/year with area closures. Limits change in-season — confirm with NOAA.",
+        notes: "NOAA HMS Angling permit required.",
+      },
+    ],
     verify: true,
   },
   {
@@ -330,7 +345,16 @@ export const species: Species[] = [
       "The stock is not overfished and is not subject to overfishing.",
     waterType: "offshore",
     permitRequired: true, // NOAA HMS
-    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS, pending verification")],
+    seasons: [
+      {
+        jurisdiction: "federal",
+        openDate: "01-01",
+        closeDate: "12-31",
+        minSizeInches: 27,
+        bagLimit: 3,
+        notes: "27 in curved fork length. NOAA HMS Angling permit required.",
+      },
+    ],
     verify: true,
   },
   {
@@ -348,7 +372,16 @@ export const species: Species[] = [
       "The stock is overfished, but the fishing rate established under a conservation and management plan promotes population growth.",
     waterType: "offshore",
     permitRequired: true, // NOAA HMS
-    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS, pending verification")],
+    seasons: [
+      {
+        jurisdiction: "federal",
+        openDate: "01-01",
+        closeDate: "12-31",
+        minSizeInches: 27,
+        limitNote: "No federal retention limit",
+        notes: "27 in curved fork length. NOAA HMS Angling permit required.",
+      },
+    ],
     verify: true,
   },
   {
@@ -366,7 +399,15 @@ export const species: Species[] = [
       "North Atlantic albacore is not overfished and not subject to overfishing.",
     waterType: "offshore",
     permitRequired: true, // NOAA HMS
-    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS, pending verification")],
+    seasons: [
+      {
+        jurisdiction: "federal",
+        openDate: "01-01",
+        closeDate: "12-31",
+        limitNote: "No minimum size or federal retention limit",
+        notes: "NOAA HMS Angling permit required.",
+      },
+    ],
     verify: true,
   },
   {
@@ -411,7 +452,18 @@ export const species: Species[] = [
     slug: "marlin-billfish",
     waterType: "offshore",
     permitRequired: true, // NOAA HMS billfish
-    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS billfish, pending verification")],
+    seasons: [
+      {
+        jurisdiction: "federal",
+        openDate: "01-01",
+        closeDate: "12-31",
+        minSizeInches: 99,
+        limitNote:
+          "No individual limit; 250/year U.S. national landings quota (blue + white marlin + roundscale spearfish combined).",
+        notes:
+          "Blue marlin 99 in / white marlin 66 in lower-jaw fork length. NOAA HMS permit; catch-and-release encouraged.",
+      },
+    ],
     verify: true,
   },
   {
@@ -429,7 +481,18 @@ export const species: Species[] = [
       "The stock is not overfished and is not subject to overfishing.",
     waterType: "offshore",
     permitRequired: true, // NOAA HMS
-    seasons: [pending("federal", "PLACEHOLDER — NOAA HMS, pending verification")],
+    seasons: [
+      {
+        jurisdiction: "federal",
+        openDate: "01-01",
+        closeDate: "12-31",
+        minSizeInches: 47,
+        bagLimit: 1,
+        limitNote: "up to 4/vessel/trip",
+        notes:
+          "47 in lower-jaw fork length (or 25 in cleithrum to keel). NOAA HMS permit required.",
+      },
+    ],
     verify: true,
   },
 ];


### PR DESCRIPTION
## Summary
Extends the schema and fills the offshore/HMS batch (the part that didn't fit the numeric model). Adds `limitNote?: string` to `Season` and fills the **six sourceable HMS species** from the NOAA HMS recreational pages. **Mahi and Wahoo stay placeholders** (couldn't be sourced for the Atlantic).

| Species | Min size | Limit | Season |
|---|---|---|---|
| Yellowfin | 27″ CFL | 3 | year-round |
| Big-Eye | 27″ CFL | No federal retention limit | year-round |
| Albacore | — | No min size or federal retention limit | year-round |
| Swordfish | 47″ LJFL | 1 (up to 4/vessel/trip) | year-round |
| Marlin (Blue) | 99″ LJFL | No individual limit; 250/yr U.S. national quota | year-round |
| Bluefin | 27″ | Category system (2/vessel/day; trophy 1/vessel/yr; area closures) | year-round |
| **Mahi / Wahoo** | — | — | **still placeholder** |

## Verify state (honest signalling)
These 6 are **sourced but not owner-confirmed**, so they keep `verify: true`. The badge now distinguishes:
- **"Unverified placeholder"** — still sentinel windows (Mahi, Wahoo)
- **"Unverified — confirm with NOAA"** — filled HMS values, pending your check against the HMS Compliance Guide

To confirm them, flip those six to `verify: false` once you've checked the [NOAA HMS guide](https://www.fisheries.noaa.gov/atlantic-highly-migratory-species).

## Verification (built HTML)
- Placeholder badges only on Mahi/Wahoo (4 = 2×2); "Unverified — confirm with NOAA" on the 6 (+disclaimer) ✓
- All `limitNote`s render (no-limit, per-vessel, 250/yr quota, bluefin category system) ✓
- Mahi/Wahoo still show "Dates pending verification" ✓
- `pnpm build` passes.

## Scope
`lib/data/speciesSeasons.ts`, `components/SeasonCalendar.tsx`, `app/species/page.tsx`. No deps, no `pnpm-lock.yaml`.

Do not self-merge — for review.