### PR TITLE
fix(contact): escape email HTML + form a11y (M1, M3, L5)

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -10,6 +10,21 @@ function getResend() {
   return new Resend(key);
 }
 
+/** Escape user input before embedding it in the notification email HTML. */
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** Collapse newlines so user input can't inject headers into the email subject. */
+function singleLine(value: unknown): string {
+  return String(value ?? "").replace(/[\r\n]+/g, " ").slice(0, 200);
+}
+
 export async function POST(request: Request) {
   try {
     const body = await request.json();
@@ -44,17 +59,17 @@ export async function POST(request: Request) {
       await resend.emails.send({
         from: `SouthStar Charters <${fromEmail}>`,
         to: [notificationEmail],
-        subject: `New Inquiry: ${inquiryType ?? "General"} from ${name}`,
+        subject: `New Inquiry: ${singleLine(inquiryType ?? "General")} from ${singleLine(name)}`,
         html: `
           <h2>New Contact Form Submission</h2>
           <table style="border-collapse:collapse;width:100%;max-width:600px;">
-            <tr><td style="padding:8px;font-weight:bold;">Name</td><td style="padding:8px;">${name}</td></tr>
-            <tr><td style="padding:8px;font-weight:bold;">Email</td><td style="padding:8px;"><a href="mailto:${email}">${email}</a></td></tr>
-            <tr><td style="padding:8px;font-weight:bold;">Phone</td><td style="padding:8px;">${phone ?? "Not provided"}</td></tr>
-            <tr><td style="padding:8px;font-weight:bold;">Inquiry Type</td><td style="padding:8px;">${inquiryType ?? "Not specified"}</td></tr>
-            <tr><td style="padding:8px;font-weight:bold;">Message</td><td style="padding:8px;">${message}</td></tr>
+            <tr><td style="padding:8px;font-weight:bold;">Name</td><td style="padding:8px;">${escapeHtml(name)}</td></tr>
+            <tr><td style="padding:8px;font-weight:bold;">Email</td><td style="padding:8px;"><a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a></td></tr>
+            <tr><td style="padding:8px;font-weight:bold;">Phone</td><td style="padding:8px;">${escapeHtml(phone ?? "Not provided")}</td></tr>
+            <tr><td style="padding:8px;font-weight:bold;">Inquiry Type</td><td style="padding:8px;">${escapeHtml(inquiryType ?? "Not specified")}</td></tr>
+            <tr><td style="padding:8px;font-weight:bold;">Message</td><td style="padding:8px;white-space:pre-wrap;">${escapeHtml(message)}</td></tr>
           </table>
-          <p style="margin-top:16px;font-size:12px;color:#666;">Lead ID: ${lead.id}</p>
+          <p style="margin-top:16px;font-size:12px;color:#666;">Lead ID: ${escapeHtml(lead.id)}</p>
         `,
       });
     }

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -74,6 +74,7 @@ export default function ContactForm() {
           type="text"
           id="name"
           name="name"
+          autoComplete="name"
           required
           className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-slate-900 shadow-sm placeholder:text-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
           placeholder="Your full name"
@@ -89,6 +90,7 @@ export default function ContactForm() {
           type="email"
           id="email"
           name="email"
+          autoComplete="email"
           required
           className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-slate-900 shadow-sm placeholder:text-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
           placeholder="you@example.com"
@@ -104,6 +106,7 @@ export default function ContactForm() {
           type="tel"
           id="phone"
           name="phone"
+          autoComplete="tel"
           className="mt-1 block w-full rounded-md border border-slate-300 px-3 py-2 text-slate-900 shadow-sm placeholder:text-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
           placeholder="(555) 555-5555"
         />
@@ -151,12 +154,18 @@ export default function ContactForm() {
 
       {/* Status Messages */}
       {formState.status === "success" && (
-        <div className="rounded-md bg-green-50 p-4 text-sm text-green-800 ring-1 ring-green-200">
+        <div
+          role="status"
+          className="rounded-md bg-green-50 p-4 text-sm text-green-800 ring-1 ring-green-200"
+        >
           {formState.message}
         </div>
       )}
       {formState.status === "error" && (
-        <div className="rounded-md bg-red-50 p-4 text-sm text-red-800 ring-1 ring-red-200">
+        <div
+          role="alert"
+          className="rounded-md bg-red-50 p-4 text-sm text-red-800 ring-1 ring-red-200"
+        >
           {formState.message}
         </div>
       )}


### PR DESCRIPTION
## Summary
Hardens the contact flow — three review-backlog items, no new deps.

- **M1 (security):** `app/api/contact/route.ts` interpolated user input **unescaped** into the Resend notification email — an HTML/email-injection vector. Added `escapeHtml()` applied to every value (name, email href + text, phone, inquiry, message, lead id); the subject runs through `singleLine()` to block header injection via newlines.
- **M3 (a11y):** success/error banners in `ContactForm.tsx` now carry `role="status"` / `role="alert"` so screen readers announce the submit result.
- **L5 (a11y/UX):** name/email/phone inputs get `autocomplete` (`name`/`email`/`tel`).

## Verification
`pnpm lint` 0 errors; typecheck + build pass. `escapeHtml` applied to all 7 interpolations; 5 a11y attributes added.

## Scope
`app/api/contact/route.ts`, `components/ContactForm.tsx`. No deps, no `pnpm-lock.yaml`.

**Not in this PR:** M2 (Zod validation + rate limiting) needs a dependency decision (`zod`) — flagged separately.

Do not self-merge — for review.