### PR TITLE
fix(a11y): accessibility sweep (L1–L4, L7)

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -33,7 +33,9 @@ export default function GalleryPage() {
           {categories.map((cat) => (
             <button
               key={cat}
+              type="button"
               onClick={() => setActive(cat)}
+              aria-pressed={active === cat}
               className={cn(
                 "rounded-full px-4 py-1.5 text-sm font-medium transition-colors",
                 active === cat
@@ -50,9 +52,9 @@ export default function GalleryPage() {
       {/* ── Gallery Grid ─────────────────────────────────────────────── */}
       <section className="px-4 pb-16 sm:pb-20">
         <div className="mx-auto grid max-w-7xl grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-          {filtered.map((img, i) => (
+          {filtered.map((img) => (
             <div
-              key={i}
+              key={img.src}
               className="group relative aspect-square overflow-hidden rounded-lg bg-slate-200"
             >
               <Image

--- a/app/reviews/page.tsx
+++ b/app/reviews/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 
 function StarRating({ rating }: { rating: number }) {
   return (
-    <div className="flex gap-0.5" aria-label={`${rating} out of 5 stars`}>
+    <div className="flex gap-0.5" role="img" aria-label={`${rating} out of 5 stars`}>
       {Array.from({ length: 5 }).map((_, i) => (
         <svg
           key={i}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -11,7 +11,7 @@ export default function Footer() {
           {/* Brand */}
           <div>
             <h3 className="text-lg font-bold text-white">{siteConfig.name}</h3>
-            <p className="mt-1 text-sm italic text-slate-400">{siteConfig.tagline}</p>
+            <p className="mt-1 text-sm italic text-slate-300">{siteConfig.tagline}</p>
             <p className="mt-4 text-sm leading-relaxed">
               Private harbor tours, fishing charters, and dive trips from Staten
               Island, NY and the New Jersey Shore.
@@ -65,7 +65,7 @@ export default function Footer() {
                   {contact.email}
                 </a>
               </p>
-              <p className="pt-1 text-xs text-slate-400">
+              <p className="pt-1 text-xs text-slate-300">
                 Departure points:{" "}
                 {locations.departurePoints
                   .map((d) => `${d.name} (${d.address.city}, ${d.address.state})`)
@@ -87,7 +87,7 @@ export default function Footer() {
                 aria-label="Facebook"
                 className="transition-colors hover:text-white"
               >
-                <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z" />
                 </svg>
               </a>
@@ -98,7 +98,7 @@ export default function Footer() {
                 aria-label="Instagram"
                 className="transition-colors hover:text-white"
               >
-                <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M12.315 2c2.43 0 2.784.013 3.808.06 1.064.049 1.791.218 2.427.465a4.902 4.902 0 011.772 1.153 4.902 4.902 0 011.153 1.772c.247.636.416 1.363.465 2.427.048 1.067.06 1.407.06 4.123v.08c0 2.643-.012 2.987-.06 4.043-.049 1.064-.218 1.791-.465 2.427a4.902 4.902 0 01-1.153 1.772 4.902 4.902 0 01-1.772 1.153c-.636.247-1.363.416-2.427.465-1.067.048-1.407.06-4.123.06h-.08c-2.643 0-2.987-.012-4.043-.06-1.064-.049-1.791-.218-2.427-.465a4.902 4.902 0 01-1.772-1.153 4.902 4.902 0 01-1.153-1.772c-.247-.636-.416-1.363-.465-2.427-.047-1.024-.06-1.379-.06-3.808v-.63c0-2.43.013-2.784.06-3.808.049-1.064.218-1.791.465-2.427a4.902 4.902 0 011.153-1.772A4.902 4.902 0 015.45 2.525c.636-.247 1.363-.416 2.427-.465C8.901 2.013 9.256 2 11.685 2h.63zm-.081 1.802h-.468c-2.456 0-2.784.011-3.807.058-.975.045-1.504.207-1.857.344-.467.182-.8.398-1.15.748-.35.35-.566.683-.748 1.15-.137.353-.3.882-.344 1.857-.047 1.023-.058 1.351-.058 3.807v.468c0 2.456.011 2.784.058 3.807.045.975.207 1.504.344 1.857.182.466.399.8.748 1.15.35.35.683.566 1.15.748.353.137.882.3 1.857.344 1.054.048 1.37.058 4.041.058h.08c2.597 0 2.917-.01 3.96-.058.976-.045 1.505-.207 1.858-.344.466-.182.8-.398 1.15-.748.35-.35.566-.683.748-1.15.137-.353.3-.882.344-1.857.048-1.055.058-1.37.058-4.041v-.08c0-2.597-.01-2.917-.058-3.96-.045-.976-.207-1.505-.344-1.858a3.097 3.097 0 00-.748-1.15 3.098 3.098 0 00-1.15-.748c-.353-.137-.882-.3-1.857-.344-1.023-.047-1.351-.058-3.807-.058zM12 6.865a5.135 5.135 0 110 10.27 5.135 5.135 0 010-10.27zm0 1.802a3.333 3.333 0 100 6.666 3.333 3.333 0 000-6.666zm5.338-3.205a1.2 1.2 0 110 2.4 1.2 1.2 0 010-2.4z" />
                 </svg>
               </a>
@@ -107,7 +107,7 @@ export default function Footer() {
         </div>
 
         {/* Bottom Bar */}
-        <div className="mt-10 border-t border-slate-700 pt-6 text-center text-xs text-slate-500">
+        <div className="mt-10 border-t border-slate-700 pt-6 text-center text-xs text-slate-400">
           <p>
             &copy; {new Date().getFullYear()} {siteConfig.name}. All rights
             reserved.

--- a/components/GalleryPreview.tsx
+++ b/components/GalleryPreview.tsx
@@ -21,9 +21,9 @@ export default function GalleryPreview({ limit = 6 }: GalleryPreviewProps) {
         </p>
 
         <div className="mt-10 grid grid-cols-2 gap-4 sm:grid-cols-3">
-          {items.map((img, i) => (
+          {items.map((img) => (
             <div
-              key={i}
+              key={img.src}
               className="group relative aspect-square overflow-hidden rounded-lg bg-slate-200"
             >
               <Image

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -44,6 +44,7 @@ export default function Header() {
           className="inline-flex items-center justify-center rounded-md p-2 text-slate-700 md:hidden"
           onClick={() => setMobileOpen(!mobileOpen)}
           aria-expanded={mobileOpen}
+          aria-controls="mobile-nav"
           aria-label="Toggle navigation menu"
         >
           <svg
@@ -52,6 +53,7 @@ export default function Header() {
             viewBox="0 0 24 24"
             strokeWidth={1.5}
             stroke="currentColor"
+            aria-hidden="true"
           >
             {mobileOpen ? (
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -64,6 +66,7 @@ export default function Header() {
 
       {/* Mobile Navigation */}
       <div
+        id="mobile-nav"
         className={cn(
           "border-t border-slate-200 bg-white md:hidden",
           mobileOpen ? "block" : "hidden"

--- a/components/TestimonialPreview.tsx
+++ b/components/TestimonialPreview.tsx
@@ -2,7 +2,7 @@ import testimonials from "@/content/testimonials.json";
 
 function StarRating({ rating }: { rating: number }) {
   return (
-    <div className="flex gap-0.5" aria-label={`${rating} out of 5 stars`}>
+    <div className="flex gap-0.5" role="img" aria-label={`${rating} out of 5 stars`}>
       {Array.from({ length: 5 }).map((_, i) => (
         <svg
           key={i}


### PR DESCRIPTION
## Summary
Clears the low-severity accessibility items from the review backlog. No behavior change.

- **L1** — gallery filter buttons: `aria-pressed` (active state was color-only) + `type="button"`.
- **L2** — gallery grids key by `img.src`, not array index (`gallery/page.tsx`, `GalleryPreview.tsx`).
- **L3** — decorative icon SVGs `aria-hidden` (header hamburger, footer social); `StarRating` containers get `role="img"` so the rating is announced as one labelled image (`TestimonialPreview`, `reviews/page.tsx`).
- **L4** — footer contrast bumped (tagline/departure `slate-400→300`, copyright `slate-500→400`) for WCAG on `slate-900`.
- **L7** — mobile menu button `aria-controls="mobile-nav"` → new `id` on the panel.

## Verification (built HTML)
gallery `aria-pressed` ✓, header `aria-controls`+`id` ✓, icon `aria-hidden` ✓, star `role="img"` ✓. `pnpm lint` 0 errors; typecheck + build pass.

## Scope
6 files (gallery, reviews, Footer, GalleryPreview, Header, TestimonialPreview). No deps.

**Residual (minor, not in this PR):** contact-page + harbor-tours decorative SVGs could also take `aria-hidden`; **L6** (Hero CSS-bg → `next/image`) is a separate refactor.

Do not self-merge — for review.