### PR TITLE
fix(contact): Zod validation + rate limiting (M2)

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { Resend } from "resend";
+import { z } from "zod";
 
 // Lazily initialize Resend so the build does not fail when the
 // RESEND_API_KEY env var is not yet set.
@@ -25,18 +26,57 @@ function singleLine(value: unknown): string {
   return String(value ?? "").replace(/[\r\n]+/g, " ").slice(0, 200);
 }
 
+/** Validated, length-capped shape of a contact submission. */
+const contactSchema = z.object({
+  name: z.string().trim().min(1, "Name is required.").max(100),
+  email: z
+    .string()
+    .trim()
+    .min(3)
+    .max(200)
+    .refine((v) => /.+@.+\..+/.test(v), "A valid email is required."),
+  phone: z.string().trim().max(50).optional(),
+  inquiryType: z.string().trim().max(100).optional(),
+  message: z.string().trim().min(1, "Message is required.").max(5000),
+});
+
+// Best-effort in-memory rate limit (per server instance). Durable, multi-instance
+// limiting (e.g. on serverless) needs an external store such as Upstash/Redis.
+const RATE_LIMIT = 5;
+const RATE_WINDOW_MS = 10 * 60 * 1000;
+const recentHitsByIp = new Map<string, number[]>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const hits = (recentHitsByIp.get(ip) ?? []).filter(
+    (t) => now - t < RATE_WINDOW_MS,
+  );
+  hits.push(now);
+  recentHitsByIp.set(ip, hits);
+  return hits.length > RATE_LIMIT;
+}
+
 export async function POST(request: Request) {
   try {
-    const body = await request.json();
-    const { name, email, phone, inquiryType, message } = body;
-
-    // ── Basic validation ──────────────────────────────────────────────
-    if (!name || !email || !message) {
+    const ip =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      "unknown";
+    if (isRateLimited(ip)) {
       return NextResponse.json(
-        { error: "Name, email, and message are required." },
+        { error: "Too many requests. Please try again in a little while." },
+        { status: 429 }
+      );
+    }
+
+    // ── Validate input (rejects oversized / malformed payloads) ───────
+    const parsed = contactSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Please check your entries and try again." },
         { status: 400 }
       );
     }
+    const { name, email, phone, inquiryType, message } = parsed.data;
 
     // ── Save lead to Neon Postgres ────────────────────────────────────
     const lead = await prisma.lead.create({

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-dom": "19.2.6",
     "react-hook-form": "^7.76.0",
     "resend": "^6.12.3",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4


### PR DESCRIPTION
## Summary
Closes review item **M2** — the contact API previously trusted an untyped `any` body with a presence-only check and had no rate limiting.

- **Validation:** `zod` schema with length caps — name ≤100, email (format + ≤200), phone ≤50, inquiryType ≤100, message ≤5000. Malformed/oversized payloads → **400**. Removes the `any` body and the manual checks.
- **Rate limiting:** best-effort in-memory per-IP limit (5 / 10 min → **429**).

## Honest caveat on rate limiting
The in-memory limiter is **per server instance** — on serverless (Vercel) instances are ephemeral, so it's a speed bump, not durable protection. Real multi-instance limiting needs an external store (Upstash/Redis). Documented in-code and flagged for a future infra decision.

## Dependency
Adds **`zod`** (you approved). `pnpm-lock.yaml` updated; `pnpm install --frozen-lockfile` consistent.

## Verification
typecheck + `pnpm build` pass; `pnpm lint` 0 errors.

## Scope
`app/api/contact/route.ts`, `package.json`, `pnpm-lock.yaml`. Builds on the M1 escaping already merged in #60.

Do not self-merge — for review.