### PR TITLE
fix(headers): de-duplicate security headers (M5)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,31 +3,6 @@
   "framework": "nextjs",
   "headers": [
     {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "X-Frame-Options",
-          "value": "DENY"
-        },
-        {
-          "key": "X-Content-Type-Options",
-          "value": "nosniff"
-        },
-        {
-          "key": "Referrer-Policy",
-          "value": "strict-origin-when-cross-origin"
-        },
-        {
-          "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=()"
-        },
-        {
-          "key": "X-DNS-Prefetch-Control",
-          "value": "on"
-        }
-      ]
-    },
-    {
       "source": "/images/(.*)",
       "headers": [
         {


### PR DESCRIPTION
Closes review item **M5**. The five security headers were defined in **both** `next.config.ts` and `vercel.json` → duplicate response headers on Vercel. Removed them from `vercel.json`; **`next.config.ts` is now the single source** (and it applies in local `next start` / any host, unlike vercel.json which is Vercel-only). `vercel.json` keeps its unique `/images/` Cache-Control header. Config-only; no build impact.

Do not self-merge — for review.