### PR TITLE
perf(hero): hero background via next/image (L6)

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 
@@ -23,11 +24,21 @@ export default function Hero({
   return (
     <section
       className={cn(
-        "relative flex min-h-[60vh] items-center justify-center bg-slate-900 bg-cover bg-center px-4 text-center text-white",
+        "relative flex min-h-[60vh] items-center justify-center overflow-hidden bg-slate-900 px-4 text-center text-white",
         className
       )}
-      style={{ backgroundImage: `url(${backgroundImage})` }}
     >
+      {/* Optimized background image. Decorative (the heading carries meaning),
+          so alt is empty; `priority` because the hero is the LCP element. */}
+      <Image
+        src={backgroundImage}
+        alt=""
+        fill
+        priority
+        sizes="100vw"
+        className="object-cover"
+      />
+
       {/* Dark overlay for text readability */}
       {overlay && (
         <div className="absolute inset-0 bg-black/50" aria-hidden="true" />


### PR DESCRIPTION
Closes review item **L6**. The Hero used an inline CSS `background-image`, bypassing Next image optimization and LCP priority. Now uses `next/image` (`fill`, `object-cover`, `priority`, empty decorative `alt`); overlay + content stack above it unchanged.

**Gains:** optimized/responsive delivery (WebP/AVIF + srcset) and LCP preload for the hero on every page that uses it (home, about, harbor-tours, fishing-charters).

Verified: built HTML serves the hero via `/_next/image`; no inline background-image styles remain; typecheck + build pass. One file (`components/Hero.tsx`).

Do not self-merge — for review.