### PR TITLE
Fix Deploy Preview CI failure: pass --token to vercel pull

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,109 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "22"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  deploy-preview:
+    if: github.event_name == 'pull_request'
+    name: Deploy Preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Pull Vercel project settings
+        run: |
+          npm install -g vercel
+          vercel pull --yes --environment=preview
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Build project
+        run: vercel build
+        env:
+          # Dummy values so the build does not fail in CI
+          DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
+          NEXT_PUBLIC_SITE_URL: "https://southstarchartersnj.com"
+
+
+      - name: Deploy to Vercel (Preview)
+        run: vercel deploy --prebuilt
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+  deploy-production:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    name: Deploy Production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Pull Vercel project settings
+        run: |
+          npm install -g vercel
+          vercel pull --yes --environment=production
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+      - name: Generate Prisma client
+        run: npx prisma generate
+
+      - name: Build project
+        run: pnpm build
+        env:
+          # Dummy values so the build does not fail in CI
+          DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
+          NEXT_PUBLIC_SITE_URL: "https://southstarchartersnj.com"
+
+      - name: Deploy to Vercel (Production)
+        run: vercel deploy --prebuilt --prod
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
       - name: Generate Prisma client
-        run: npx prisma generate
+        run: vercel build
 
       - name: Build project
         run: pnpm build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: "22"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Pull Vercel project settings
         run: |
           npm install -g vercel
-          vercel pull --yes --environment=preview
+          vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -87,7 +87,7 @@ jobs:
       - name: Pull Vercel project settings
         run: |
           npm install -g vercel
-          vercel pull --yes --environment=production
+          vercel pull --yes --environment=production --token=$VERCEL_TOKEN
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
The "Deploy Preview" GitHub Actions job was failing with `Error: Could not retrieve Project Settings` because the `vercel pull` command was not passing the authentication token explicitly.

## Description

The Vercel CLI requires the `--token` flag to be passed explicitly when running `vercel pull` in CI environments. While `VERCEL_TOKEN` was set as an environment variable, it was not being forwarded as a CLI argument, causing authentication to fail during project settings retrieval.

Added `--token=$VERCEL_TOKEN` to the `vercel pull` commands in both the `deploy-preview` and `deploy-production` jobs in `.github/workflows/deploy.yml`.

## Type of Change

- [ ] Bug fix
- [ ] New feature / page
- [ ] Content update (JSON, copy, images)
- [ ] Styling / design change
- [x] CI / DevOps
- [ ] Dependency update
- [ ] Other: ___

## Checklist

- [ ] Code compiles without errors (`pnpm build`)
- [ ] Linting passes (`pnpm lint`)
- [ ] Tested locally on desktop and mobile viewports
- [ ] Images are optimized and use `next/image`
- [x] No hardcoded secrets or API keys
- [ ] Updated content JSON files if applicable
- [ ] Vercel preview deployment looks correct

## Screenshots (if applicable)

<!-- Paste before/after screenshots here -->