### PR TITLE
fix(ci): remove duplicate permissions key in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,6 @@ concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
 env:
   NODE_VERSION: "22"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Problem
The **Deploy to Vercel** workflow fails to parse:

> `.github/workflows/deploy.yml` — Invalid workflow file (Line: 16, Col: 1): `'permissions' is already defined`

`deploy.yml` declared a top-level `permissions:` block **twice** — once after `on:` (lines 9–10) and again right before `env:` (lines 16–17, added alongside #77). GitHub rejects the whole file, so the workflow can't run.

## Fix
Removed the second, duplicate `permissions: { contents: read }` block. One block remains; all five workflow files parse cleanly (verified with a strict YAML load).

One file, CI-config only.

Do not self-merge — for review.