### PR TITLE
fix(contact): deliver submissions via Web3Forms email, drop database dependency

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -42,8 +42,17 @@ unused and can be deleted.
 - Framework: **Next.js** (auto-detected by Vercel).
 - Package manager: **pnpm** (pinned via `packageManager` in `package.json`).
 - Required environment variables (set in Vercel → Settings → Environment Variables):
-  - `DATABASE_URL` — Neon Postgres connection string.
   - `NEXT_PUBLIC_SITE_URL` — `https://southstarchartersnj.com`.
+- Optional environment variables:
+  - `WEB3FORMS_ACCESS_KEY` — [Web3Forms](https://web3forms.com) access key the contact
+    form uses to email submissions. A working key is committed as the default in
+    `app/api/contact/route.ts` (Web3Forms keys are designed to be public), so the form
+    works with **no configuration**. Only set this env var to **rotate** the key —
+    generate a new one in the Web3Forms dashboard and the env var overrides the default
+    with no code change.
+  - `DATABASE_URL` — **no longer required.** The contact form no longer uses a database;
+    submissions are delivered by email via Web3Forms. The Prisma client is still generated
+    at build time, so a dummy value is harmless, but no real database is needed.
 
 ## Before production launch — SSL check
 
@@ -69,7 +78,8 @@ invalid or expired.
 ## Production launch checklist
 
 - [ ] Vercel **Production Branch = `main`**, auto-deploy on, domain assigned to Production.
-- [ ] `DATABASE_URL` and `NEXT_PUBLIC_SITE_URL` set in Vercel env vars.
+- [ ] `NEXT_PUBLIC_SITE_URL` set in Vercel env vars.
+- [ ] Submit the live contact form once and confirm the email arrives (Web3Forms).
 - [ ] `https://southstarchartersnj.com` has a valid SSL/TLS certificate.
 - [ ] Remove the `-k` flag from `curl` in `.github/workflows/security-headers.yml`.
 - [ ] Confirm all security headers pass in the "Verify Security Headers" workflow.

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,29 +1,25 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
-import { Resend } from "resend";
 import { z } from "zod";
 
-// Lazily initialize Resend so the build does not fail when the
-// RESEND_API_KEY env var is not yet set.
-function getResend() {
-  const key = process.env.RESEND_API_KEY;
-  if (!key) return null;
-  return new Resend(key);
-}
-
-/** Escape user input before embedding it in the notification email HTML. */
-function escapeHtml(value: unknown): string {
-  return String(value ?? "")
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
+// Contact submissions are delivered by email via Web3Forms (https://web3forms.com).
+// There is no database: the API route validates and rate-limits the request, then
+// forwards it to Web3Forms, which emails the submission to the address tied to the
+// access key.
+//
+// Web3Forms access keys are designed to be public — their own recommended
+// integration embeds the key in the client-side bundle — so the default below is
+// safe to commit and lets the form work with no extra configuration. To rotate
+// the key (e.g. if it gets abused), generate a new one in the Web3Forms dashboard
+// and set WEB3FORMS_ACCESS_KEY in Vercel → Settings → Environment Variables; the
+// env var overrides the default with no code change.
+const WEB3FORMS_ENDPOINT = "https://api.web3forms.com/submit";
+const DEFAULT_WEB3FORMS_ACCESS_KEY = "96d7226e-42ac-4afb-80c3-a51bd290a3aa";
 
 /** Collapse newlines so user input can't inject headers into the email subject. */
 function singleLine(value: unknown): string {
-  return String(value ?? "").replace(/[\r\n]+/g, " ").slice(0, 200);
+  return String(value ?? "")
+    .replace(/[\r\n]+/g, " ")
+    .slice(0, 200);
 }
 
 /** Validated, length-capped shape of a contact submission. */
@@ -64,7 +60,7 @@ export async function POST(request: Request) {
     if (isRateLimited(ip)) {
       return NextResponse.json(
         { error: "Too many requests. Please try again in a little while." },
-        { status: 429 }
+        { status: 429 },
       );
     }
 
@@ -73,56 +69,57 @@ export async function POST(request: Request) {
     if (!parsed.success) {
       return NextResponse.json(
         { error: "Please check your entries and try again." },
-        { status: 400 }
+        { status: 400 },
       );
     }
     const { name, email, phone, inquiryType, message } = parsed.data;
 
-    // ── Save lead to Neon Postgres ────────────────────────────────────
-    const lead = await prisma.lead.create({
-      data: {
+    const accessKey =
+      process.env.WEB3FORMS_ACCESS_KEY || DEFAULT_WEB3FORMS_ACCESS_KEY;
+
+    // ── Forward to Web3Forms, which emails the submission ─────────────
+    const response = await fetch(WEB3FORMS_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        access_key: accessKey,
+        subject: `New Inquiry: ${singleLine(inquiryType ?? "General")} from ${singleLine(name)}`,
+        from_name: "SouthStar Charters Website",
+        // Lets you hit "Reply" in your inbox to answer the customer directly.
+        replyto: email,
         name,
         email,
-        phone: phone ?? null,
-        inquiryType: inquiryType ?? null,
+        phone: phone ?? "Not provided",
+        inquiry_type: inquiryType ?? "Not specified",
         message,
-        source: "Contact Form",
-      },
+      }),
     });
 
-    // ── Send email notification via Resend ────────────────────────────
-    const resend = getResend();
-    const notificationEmail = process.env.CONTACT_NOTIFICATION_EMAIL;
-    const fromEmail = process.env.CONTACT_FROM_EMAIL ?? "onboarding@resend.dev";
+    const result = (await response.json().catch(() => null)) as
+      | { success?: boolean; message?: string }
+      | null;
 
-    if (resend && notificationEmail) {
-      await resend.emails.send({
-        from: `SouthStar Charters <${fromEmail}>`,
-        to: [notificationEmail],
-        subject: `New Inquiry: ${singleLine(inquiryType ?? "General")} from ${singleLine(name)}`,
-        html: `
-          <h2>New Contact Form Submission</h2>
-          <table style="border-collapse:collapse;width:100%;max-width:600px;">
-            <tr><td style="padding:8px;font-weight:bold;">Name</td><td style="padding:8px;">${escapeHtml(name)}</td></tr>
-            <tr><td style="padding:8px;font-weight:bold;">Email</td><td style="padding:8px;"><a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a></td></tr>
-            <tr><td style="padding:8px;font-weight:bold;">Phone</td><td style="padding:8px;">${escapeHtml(phone ?? "Not provided")}</td></tr>
-            <tr><td style="padding:8px;font-weight:bold;">Inquiry Type</td><td style="padding:8px;">${escapeHtml(inquiryType ?? "Not specified")}</td></tr>
-            <tr><td style="padding:8px;font-weight:bold;">Message</td><td style="padding:8px;white-space:pre-wrap;">${escapeHtml(message)}</td></tr>
-          </table>
-          <p style="margin-top:16px;font-size:12px;color:#666;">Lead ID: ${escapeHtml(lead.id)}</p>
-        `,
-      });
+    if (!response.ok || !result?.success) {
+      console.error(
+        "Web3Forms submission failed:",
+        response.status,
+        result?.message ?? "no response body",
+      );
+      return NextResponse.json(
+        { error: "An unexpected error occurred. Please try again later." },
+        { status: 502 },
+      );
     }
 
-    return NextResponse.json(
-      { success: true, id: lead.id },
-      { status: 201 }
-    );
+    return NextResponse.json({ success: true }, { status: 200 });
   } catch (error) {
     console.error("Contact form error:", error);
     return NextResponse.json(
       { error: "An unexpected error occurred. Please try again later." },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
## Problem

The contact form's **Submit** button returned `An unexpected error occurred. Please try again later.` (HTTP 500). Root cause: `app/api/contact/route.ts` wrote each submission to a Postgres database via `prisma.lead.create(...)`, but **there is no database** — so every submission threw.

## Fix

Replace the database write (and the unused Resend email path) with a server-side POST to **[Web3Forms](https://web3forms.com)**, which emails each submission to the address tied to the access key. No database required.

What's preserved:
- The existing styled **ContactForm** (name / email / phone / inquiry-type / message) — unchanged, still posts to `/api/contact`.
- Zod validation + length caps.
- In-memory rate limiting (5 / 10 min per IP).
- Header-injection-safe email subject.

What changed in the route:
- Removed `prisma` + `resend` imports and the `prisma.lead.create` call.
- POST to `https://api.web3forms.com/submit` with the validated fields; sets `replyto` to the customer's email so you can reply directly from your inbox.
- Returns `200 {success:true}` on success, `502` if Web3Forms rejects, `400`/`429` as before.

## Configuration — none required

The Web3Forms access key is committed as a default. Web3Forms keys are **designed to be public** (their own recommended integration embeds the key in the client-side bundle), so this is safe and means the form works the moment this deploys — **no Vercel env-var step needed**.

To rotate the key later: generate a new one in the Web3Forms dashboard and set `WEB3FORMS_ACCESS_KEY` in Vercel → Settings → Environment Variables. The env var overrides the committed default with no code change.

`DATABASE_URL` is no longer required at runtime (`DEPLOYMENT.md` updated).

## Follow-up (not in this PR)

`lib/prisma.ts`, the Prisma dependencies, `prisma/schema.prisma`, `prisma.config.ts`, and the `prisma-check` workflow are now unused dead code. They can be removed in a focused follow-up PR to drop the DB stack entirely.

## Verification

- `pnpm lint` — 0 errors (2 pre-existing warnings in unrelated files).
- `npx tsc --noEmit` — clean.
- `pnpm build` — succeeds.
- After merge: submit the live form once and confirm the email arrives.